### PR TITLE
run beforeBuild hook before validating on serve

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -76,9 +76,9 @@ module.exports = Command.extend({
     let ui = this.ui;
 
     return editXml.addNavigation(project, reloadUrl)
+      .then(() => hook.run('beforeBuild', opts))
       .then(() => cordovaTarget.validateServe())
       .then(() => framework.validateServe(opts))
-      .then(() => hook.run('beforeBuild', opts))
       .then(() => setupLivereload.run(reloadUrl))
       .then(function() {
         if (opts.skipCordovaBuild !== true) {

--- a/node-tests/unit/commands/serve-test.js
+++ b/node-tests/unit/commands/serve-test.js
@@ -114,11 +114,11 @@ describe('Serve Command', function() {
   it('runs tasks in the correct order', function() {
     return serveCmd.run({}).then(function() {
       expect(tasks).to.deep.equal([
+        'hook beforeBuild',
         'validate-allow-navigation',
         'validate-platform',
         'validate-plugin',
         'framework-validate-serve',
-        'hook beforeBuild',
         'create-livereload-shell',
         'cordova-build',
         'hook afterBuild',
@@ -146,11 +146,11 @@ describe('Serve Command', function() {
       skipCordovaBuild: true
     }).then(function() {
       expect(tasks).to.deep.equal([
+        'hook beforeBuild',
         'validate-allow-navigation',
         'validate-platform',
         'validate-plugin',
         'framework-validate-serve',
-        'hook beforeBuild',
         'create-livereload-shell',
         'hook afterBuild'
       ]);


### PR DESCRIPTION
- mirrors `build` behavior
- allows usage of before-build hook example of dynamic environemt
settings