### PR TITLE
Separate ember-cli and Ember projects after #389

### DIFF
--- a/bin/corber
+++ b/bin/corber
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
 'use strict';
 
-process.title       = 'corber';
+process.title               = 'corber';
 
-const CLI           = require('../node_modules/ember-cli/lib/cli/cli.js');
-const Project       = require('../node_modules/ember-cli/lib/models/project.js');
-const UI            = require('console-ui');
-const resolve       = require('resolve');
-const path          = require('path');
-const requireAsHash = require('../node_modules/ember-cli/lib/utilities/require-as-hash');
+const CLI                   = require('../node_modules/ember-cli/lib/cli/cli.js');
+const Project               = require('../node_modules/ember-cli/lib/models/project.js');
+const UI                    = require('console-ui');
+const resolve               = require('resolve');
+const path                  = require('path');
+const requireAsHash         = require('../node_modules/ember-cli/lib/utilities/require-as-hash');
+const willInterruptProcess  = require('../node_modules/ember-cli/lib/utilities/will-interrupt-process');
+
+// `process` should be captured before we require any libraries which
+// may use `process.exit` work arounds for async cleanup.
+// See https://github.com/ember-cli/ember-cli/blob/953ba590d103fdf1161a385deb134805b6770553/lib/cli/index.js#L68
+willInterruptProcess.capture(process);
 
 function loadCommands() {
   const Command = require('../node_modules/ember-cli/lib/models/command.js');

--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -1,4 +1,4 @@
-const Command          = require('ember-cli/lib/models/command');
+const Command          = require('../../node_modules/ember-cli/lib/models/command');
 const Leek             = require('leek');
 const ConfigStore      = require('configstore');
 const uuid             = require('uuid');

--- a/lib/frameworks/ember/tasks/build.js
+++ b/lib/frameworks/ember/tasks/build.js
@@ -1,6 +1,7 @@
 const Builder          = require('ember-cli/lib/models/builder');
 const Task             = require('../../../tasks/-task');
 const createGitkeep    = require('../../../utils/create-gitkeep');
+const willInterruptProcess  = require('../../../../node_modules/ember-cli/lib/utilities/will-interrupt-process');
 
 module.exports = Task.extend({
   project: undefined,
@@ -11,7 +12,8 @@ module.exports = Task.extend({
     return new Builder({
       project: this.project,
       environment: this.environment,
-      outputPath: this.outputPath
+      outputPath: this.outputPath,
+      onProcessInterrupt: willInterruptProcess
     });
   },
 

--- a/lib/tasks/-task.js
+++ b/lib/tasks/-task.js
@@ -1,3 +1,3 @@
-const Task             = require('ember-cli/lib/models/task');
+const Task             = require('../../node_modules/ember-cli/lib/models/task');
 
 module.exports = Task.extend();


### PR DESCRIPTION
This PR follows up on #387 (and the related #389).

It continues to clean up which ember-cli to use:
* the one embedded in corber when using the CLI/UI classes
* the one of the project when dealing with Ember projects

In particular, it delegates the `will-interrupt-process` module from the first one to the second one, so that when calling a command, it does not fail because `process is not captured`.

I'm not sure how to test nor what to test in this PR, any help is welcome.