### PR TITLE
feat(livereload): fix/improve livereload landing page

### DIFF
--- a/lib/templates/livereload-shell/index.html
+++ b/lib/templates/livereload-shell/index.html
@@ -1,12 +1,30 @@
 <html>
+  <head>
+    <meta name="viewport" content="initial-scale=1, width=device-width, maximum-scale=1.0, user-scalable=no, minimal-ui">
+    <style type="text/css" media="all">
+      body { font-family: Arial, sans-serif; }
+    </style>
+  </head>
   <body>
-  <script type="text/javascript">
-    var url = '{{liveReloadUrl}}';
-    if (window.location.href.indexOf('file://') > -1) {
-      window.location.replace(url);
-    }
-  </script>
+    <h2>Welcome to corber</h2>
 
-  Starting Live Reload
+    <h3>Starting Live Reload</h3>
+
+    <p>
+      Redirecting to your app now; if you still see this
+      page after a few seconds, make sure this device
+      is connected to the same network that your
+      corber build server is running on, and that
+      your build server's address ({{liveReloadUrl}})
+      can be accessed by other devices on the network.
+    </p>
+
+    <script type="text/javascript">
+      var url = '{{liveReloadUrl}}';
+      if (window.location.href.indexOf('file://') > -1) {
+        window.location.replace(url);
+      }
+    </script>
   </body>
 </html>
+


### PR DESCRIPTION
Prior to this change, if you forget to connect
your phone to the same network as the build
server, you'd just see a white screen with
no explanation (the synchronous `replace()`
call fails and stopped any further rendering).

Now it displays a little more helpful info