### PR TITLE
Add missing space in error message

### DIFF
--- a/lib/targets/cordova/tasks/open-app.js
+++ b/lib/targets/cordova/tasks/open-app.js
@@ -27,7 +27,7 @@ module.exports = Task.extend({
       } else {
         let docLink = 'http://embercordova.com/pages/cli#open';
 
-        logger.warn('Can\'t open IDE without a project being created. See' +
+        logger.warn('Can\'t open IDE without a project being created. See ' +
           docLink +
           'for more info.'
         );


### PR DESCRIPTION
… so you can tap the documentation link.