### PR TITLE
Pass build options in argv style as well

### DIFF
--- a/lib/targets/cordova/utils/parse-build-flags.js
+++ b/lib/targets/cordova/utils/parse-build-flags.js
@@ -33,13 +33,18 @@ const ANDROID_OPTS = [
 ];
 
 module.exports = function(platform, options) {
-  let buildKeys;
+  let platformKeys = [];
 
   if (platform === 'ios') {
-    buildKeys = CORDOVA_OPTS.concat(IOS_OPTS);
+    platformKeys = IOS_OPTS;
   } else if (platform === 'android') {
-    buildKeys = CORDOVA_OPTS.concat(ANDROID_OPTS);
+    platformKeys = ANDROID_OPTS;
   }
 
-  return _pick(options, buildKeys);
+  let ret = _pick(options, CORDOVA_OPTS.concat(platformKeys));
+  ret.argv = [].concat(...platformKeys
+    .filter((key) => options.hasOwnProperty(key))
+    .map((key) => [`--${key}`, options[key]]));
+
+  return ret;
 };


### PR DESCRIPTION
Fixes #417.

Turns out the platform build arguments are meant to be passed in `argv` style separately to the main cordova ones (c.f. having to put `--` between them for `cordova build`). Or at least sometimes... who knows, it's cordova.

`cordova-android` prefers the `argv` style, and the "backwards compatibility" is dodgy in that it can't handle camelCase arguments like `storePassword`. This is probably a bug in `cordova-android` or `nopt` but oh well. However, `cordova-ios` doesn't support `argv` style at all, so even doing `cordova build --platform ios -- --foo bar` doesn't work... a `cordova-ios` bug I guess.

I've left it passing the arguments in both forms, which will hopefully be compatible with everything. I tested on my project and I can create signed builds for both platforms as expected.