### PR TITLE
adds --add-cordova-js flag to build command

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -26,6 +26,7 @@ module.exports = Command.extend({
     { name: 'force',                               type: Boolean, default: false },
     { name: 'skip-cordova-build',                  type: Boolean, default: false, aliases: ['scb']},
     { name: 'skip-framework-build',                type: Boolean, default: false, aliases: ['sfb'] },
+    { name: 'add-cordova-js',                      type: Boolean },
     { name: 'quiet',                               type: Boolean, default: false, aliases: ['q'] },
 
     // iOS Signing Options
@@ -84,7 +85,15 @@ module.exports = Command.extend({
       .then(() => cordovaTarget.validateBuild(options.skipCordovaBuild))
       .then(() => {
         if (options.skipFrameworkBuild !== true) {
-          return framework.build(options).then(() => addCordovaJS.run());
+          return framework.build(options);
+        }
+      })
+      .then(() => {
+        if (
+          options.skipFrameworkBuild !== true ||
+          options.addCordovaJs === true
+        ) {
+          return addCordovaJS.run();
         }
       })
       .then(() => {

--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -129,6 +129,26 @@ describe('Build Command', function() {
     });
   });
 
+  it('adds cordova-js with --add-cordova-js --skip-framework-build flags', function() {
+    let build = setupBuild();
+    baseOpts.skipFrameworkBuild = true;
+    baseOpts.addCordovaJs = true;
+
+    return build.run(baseOpts)
+    .then(function() {
+      //h-t ember-electron for the pattern
+      expect(tasks).to.deep.equal([
+        'hook beforeBuild',
+        'framework-validate-build',
+        'cordova-target-validate-build',
+        'add-cordova-js',
+        'cordova-target-build',
+        'hook afterBuild',
+        'lint-index'
+      ]);
+    });
+  });
+
   it('skips cordova-build with the --skip-cordova-build flag', function() {
     let build = setupBuild();
     baseOpts.skipCordovaBuild = true;


### PR DESCRIPTION
Allow to add javascripts assets needed by cordova even if --skip-framework-build
flag is given. Since adding cordova javascript is something beetween framework
and cordova build this should be supported. It allows us to reuse an ember build
for web browsers as web assets for a cordova builds.