### PR TITLE
adds support for node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "7"
   - "6"
   - "8"
+  - "9"
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "./node_modules/.bin/mocha --harmony --compilers js:babel-register 'node-tests/**/*-test.js'"
   },
   "engines": {
-    "node": "^4.5 || 6.* || 7.* || 8.*"
+    "node": "^4.5 || >=6.*"
   },
   "bin": {
     "corber": "./bin/corber"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,10 +2668,6 @@ es6-map@^0.1.3, es6-map@^0.1.5:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-promise@^3.1.2:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
-
 es6-promise@~4.0.3:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
@@ -3178,14 +3174,6 @@ fs-extra@^2.0.0:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
-
-fs-extra@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^3.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^4.0.0:
   version "4.0.2"
@@ -4073,12 +4061,6 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -4187,11 +4169,9 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
-loaderjs@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/loaderjs/-/loaderjs-0.1.8.tgz#e68b5b9b534cf19fc3e50cd9ec059a1305c26d88"
-  dependencies:
-    es6-promise "^3.1.2"
+loaderjs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/loaderjs/-/loaderjs-0.2.0.tgz#99e1f7b9dafc656972f4a6872bcc018a2eb40a90"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Node 9 is current release. If corber is following [Ember Node.js LTS Support](https://www.emberjs.com/blog/2016/09/07/ember-node-lts-support.html) it should be supported.