### PR TITLE
Fix log level value

### DIFF
--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -43,7 +43,7 @@ module.exports = Command.extend({
     }
     if (options && options.verbose) {
       logger.setLogLevel('verbose');
-      this.ui.setWriteLevel('verbose');
+      this.ui.setWriteLevel('DEBUG');
     }
 
     this.analytics.track({


### PR DESCRIPTION
Fixes this error message when passing `-v` flag through to any corber command:

```
Unknown write level. Valid values are 'DEBUG', 'INFO', 'WARNING', and 'ERROR'.
```

Can see found here:
https://github.com/ember-cli/console-ui/blob/master/lib/index.js#L186