### PR TITLE
Fix/update get platforms

### DIFF
--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -15,7 +15,7 @@ module.exports = Command.extend({
   /* eslint-disable max-len */
   availableOptions: [
     { name: 'save',                 type: Boolean,  default: true },
-    { name: 'letiable',             type: Array, aliases: ['var'] },
+    { name: 'variable',             type: Array, aliases: ['var'] },
     { name: 'searchpath',           type: String },
     { name: 'noregistry',           type: Boolean, default: false },
     { name: 'nohooks',              type: Boolean, default: false },
@@ -51,7 +51,8 @@ module.exports = Command.extend({
           browserify: options.browserify,
           link: options.link,
           force: options.force,
-          cli_letiables: validated.varOpts
+          cli_variables: validated.varOpts,
+          fetch: true
         });
 
       }).catch(function(err) {

--- a/lib/targets/cordova/tasks/platform.js
+++ b/lib/targets/cordova/tasks/platform.js
@@ -6,7 +6,7 @@ module.exports = Task.extend({
   project: undefined,
 
   run(action, platform, opts) {
-    let saveOpts = { save: opts.save, link: opts.link };
+    let saveOpts = { save: opts.save, link: opts.link, fetch: true };
 
     let platformTask = new CordovaRaw({
       project: this.project,

--- a/lib/targets/cordova/tasks/prepare.js
+++ b/lib/targets/cordova/tasks/prepare.js
@@ -12,6 +12,6 @@ module.exports = Task.extend({
       api: 'prepare',
     });
 
-    return prepare.run();
+    return prepare.run({ fetch: true });
   }
 });

--- a/lib/targets/cordova/utils/get-platforms.js
+++ b/lib/targets/cordova/utils/get-platforms.js
@@ -1,16 +1,34 @@
 const getCordovaPath   = require('../utils/get-path');
+//const existsSync      = require('../../../utils/fs-utils').existsSync;
 const path             = require('path');
 
 module.exports = function(project) {
   let cordovaPath = getCordovaPath(project);
   let platformsPath = path.join(cordovaPath, 'platforms/platforms.json');
-  let platformVersions = {};
+  let packagePath = path.join(cordovaPath, 'package.json');
 
-  try {
-    platformVersions = require(platformsPath);
-  } catch (e) {
-    if (!e.message.match(/Cannot find module/)) { throw e; }
+  let moduleExists = path => {
+    try {
+      require(path);
+      return true;
+    }
+    catch (e) {
+      return false;
+    }
   }
 
-  return Object.keys(platformVersions);
+  let getFromPlatforms = () => {
+    return Object.keys(require(platformsPath));
+  };
+
+  let getFromPackage = () => {
+    return require(packagePath).cordova.platforms;
+  };
+
+  try {
+    return moduleExists(platformsPath) ? getFromPlatforms() : getFromPackage();
+  } catch (e) {
+    if (!e.message.match(/Cannot find module/)) { throw e; }
+    return [];
+  }
 }

--- a/node-tests/unit/commands/plugin-test.js
+++ b/node-tests/unit/commands/plugin-test.js
@@ -35,4 +35,10 @@ describe('Plugin Command', function() {
       td.verify(rawDouble('add', 'cordova-plugin', contains({ save: false })));
     });
   });
+
+  it('defaults fetch to true', function() {
+    return plugin.run({}, ['add', 'cordova-plugin']).then(function() {
+      td.verify(rawDouble('add', 'cordova-plugin', contains({ fetch: true })));
+    });
+  });
 });

--- a/node-tests/unit/targets/cordova/tasks/platform-test.js
+++ b/node-tests/unit/targets/cordova/tasks/platform-test.js
@@ -33,18 +33,36 @@ describe('Platform Command', function() {
     });
   });
 
-  it('passes the save flag', function() {
-    let platform = setupTask();
-    var rawOpts;
-    var opts = { save: false };
+  describe('flags', function() {
+    let platform, rawOpts;
+    beforeEach(function() {
+      platform = setupTask();
+      rawOpts;
 
-    td.replace(CdvRawTask.prototype, 'run', function(cmd, plugins, options) {
-      rawOpts = options;
-      return Promise.resolve();
+      td.replace(CdvRawTask.prototype, 'run', function(cmd, plugins, options) {
+        rawOpts = options;
+        return Promise.resolve();
+      });
     });
 
-    return platform.run('add', 'ios', opts).then(function() {
-      expect(rawOpts).to.have.property('save').and.equal(false);
+    afterEach(function() {
+      platform = undefined;
+      rawOpts = undefined;
+      td.reset();
+    });
+
+    it('passes the save flag', function() {
+      let opts = { save: false };
+
+      return platform.run('add', 'ios', opts).then(function() {
+        expect(rawOpts).to.have.property('save').and.equal(false);
+      });
+    });
+
+    it('defaults the fetch flag', function() {
+      return platform.run('add', 'ios', {}).then(function() {
+        expect(rawOpts).to.have.property('fetch').and.equal(true);
+      });
     });
   });
 

--- a/node-tests/unit/targets/cordova/tasks/prepare-test.js
+++ b/node-tests/unit/targets/cordova/tasks/prepare-test.js
@@ -12,11 +12,11 @@ describe('Cordova Prepare Task', function() {
     td.reset();
   });
 
-  it('runs cordova prepare', function() {
+  it('runs cordova prepare with fetch defaulted', function() {
     var rawDouble = td.replace(CdvRawTask.prototype, 'run');
     var prepare = setupPrepareTask();
     prepare.run();
 
-    td.verify(rawDouble());
+    td.verify(new rawDouble({fetch: true}));
   });
 });

--- a/node-tests/unit/targets/cordova/utils/get-platforms-test.js
+++ b/node-tests/unit/targets/cordova/utils/get-platforms-test.js
@@ -7,14 +7,16 @@ var path            = require('path');
 var mockProject     = require('../../../../fixtures/corber-mock/project');
 
 describe('Get Added Platforms Util', function() {
-  context('when project has platforms.json', function() {
+  context('when project has platforms.json, use it over package.json', function() {
     let subject;
 
     beforeEach(function() {
       var cordovaPath = getCordovaPath(mockProject.project);
       var platformsPath = path.join(cordovaPath, 'platforms/platforms.json');
+      var packagePath = path.join(cordovaPath, 'package.json');
 
       td.replace(platformsPath, { 'ios': '4.3.1' });
+      td.replace(packagePath, { 'cordova': { 'platforms': ['android'] } });
 
       var getAddedPlatforms = require('../../../../../lib/targets/cordova/utils/get-platforms');
 
@@ -30,7 +32,33 @@ describe('Get Added Platforms Util', function() {
     });
   });
 
-  context('when project has no platforms.json', function() {
+  context('fallback to package.json when project has no platforms.json', function() {
+
+    let subject;
+
+    beforeEach(function() {
+      var cordovaPath = getCordovaPath(mockProject.project);
+      var packagePath = path.join(cordovaPath, 'package.json');
+
+      td.replace(packagePath, { 'cordova': { 'platforms': ['android'] } });
+
+      // Context relies on mockProject not including a platform.json.
+      var getAddedPlatforms = require('../../../../../lib/targets/cordova/utils/get-platforms');
+
+      subject = getAddedPlatforms(mockProject.project);
+    });
+
+    afterEach(function() {
+      td.reset();
+    });
+
+    it('returns an empty array', function() {
+      expect(subject).to.deep.equal(['android']);
+    });
+  });
+
+  context('when project has no platforms.json or package.json', function() {
+
     let subject;
 
     beforeEach(function() {


### PR DESCRIPTION
Update `get-platforms` to try the legacy `platforms.json` file, before falling back to the new `package.json` approach