### PR TITLE
Fix serve build when using android 7.0.0

### DIFF
--- a/lib/targets/cordova/utils/cordova-assets.js
+++ b/lib/targets/cordova/utils/cordova-assets.js
@@ -11,6 +11,11 @@ module.exports = {
       assetsPath = path.join(platformsPath, 'ios', 'www');
     } else if (platform === 'android') {
       assetsPath = path.join(platformsPath, 'android', 'assets', 'www');
+      // cordova-android 7.0 no longer provides assets/www path.
+      // so use android/platform_www instead
+      if (!this._exists(assetsPath)) {
+        assetsPath = path.join(platformsPath, 'android', 'platform_www');
+      }
     } else if (platform === 'browser') {
       assetsPath = path.join(platformsPath, 'browser', 'www');
     }
@@ -18,7 +23,7 @@ module.exports = {
     let files = ['cordova_plugins.js', 'cordova.js'];
 
     let pluginPath = path.join(projectPath, assetsPath, 'plugins');
-    if (existsSync(pluginPath)) {
+    if (this._exists(pluginPath)) {
       files.push('plugins/**');
     }
 
@@ -44,6 +49,10 @@ module.exports = {
         '. Ember App LiveReload will still work, but device & plugin APIS will fail.'
       );
     }
-  }
+  },
   /* eslint-enable max-len */
+
+  _exists(path) {
+    return existsSync(path);
+  }
 };

--- a/node-tests/unit/targets/cordova/utils/cordova-assets-test.js
+++ b/node-tests/unit/targets/cordova/utils/cordova-assets-test.js
@@ -13,9 +13,17 @@ describe('Get Platform Assets Util', function() {
       expect(assets.assetsPath).to.equal(expectedPath);
     });
 
-    it('is valid for android', function() {
+    it('pre cordova-android 7.0 is valid for android', function() {
+      cordovaAssets._exists = () => { return true; }
       var assets = cordovaAssets.getPaths('android', 'fakeProjectPath');
       var expectedPath = 'platforms/android/assets/www';
+      expect(assets.assetsPath).to.equal(expectedPath);
+    });
+
+    it('post cordova-android 7.0 is valid for android', function() {
+      cordovaAssets._exists = () => { return false; }
+      var assets = cordovaAssets.getPaths('android', 'fakeProjectPath');
+      var expectedPath = 'platforms/android/platform_www';
       expect(assets.assetsPath).to.equal(expectedPath);
     });
 


### PR DESCRIPTION
Point the cordova-assets that the platform_www directory if the default cannot be found so that `cordova.js` gets correctly injected into live reload builds.

Resolves this issue: https://github.com/isleofcode/corber/issues/435

Note that this will become less important once the `start` command is out of beta

