### PR TITLE
fix(cli): disable ember-cli dependency checker

### DIFF
--- a/bin/corber
+++ b/bin/corber
@@ -39,7 +39,8 @@ let cli = new CLI({
   ui,
   name: 'corber',
   npmPackage: 'corber',
-  root: path.resolve(__dirname, '..')
+  root: path.resolve(__dirname, '..'),
+  disableDependencyChecker: true
 });
 
 let project = Project.projectOrnullProject(ui, cli);


### PR DESCRIPTION
Resolves #441.

Ember CLI's dependency checker is badly broken for non-ember-cli projects. In this case:

- The `project` is loaded as a `NullProject` without the `pkg` property which contains the dependencies object loaded from `package.json` (https://github.com/ember-cli/ember-cli/blob/fe6d773f94461d048c6b15d5d99b967abb917cb6/lib/models/project.js#L648).

- `resolveSync()` does not prepend `node_modules` to the path searched for a dependency's `package.json` (https://github.com/ember-cli/ember-cli/blob/fe6d773f94461d048c6b15d5d99b967abb917cb6/lib/models/project.js#L327).

- `hasDependencies()` returns false if there are no dependencies. (https://github.com/ember-cli/ember-cli/blob/fe6d773f94461d048c6b15d5d99b967abb917cb6/lib/models/project.js#L127).

Since we are gaining little from this check, it makes sense to use the built-in disable switch.