### PR TITLE
Fix livereload page

### DIFF
--- a/lib/templates/livereload-shell/index.html
+++ b/lib/templates/livereload-shell/index.html
@@ -30,10 +30,9 @@
      setTimeout(function() {
        clearInterval(redirect);
 
-       let content = document.getElementsByTagName('p')[0].innerText;
+       var content = document.getElementsByTagName('p')[0].innerText;
        alert(content);
      }, 5000);
     </script>
   </body>
 </html>
-


### PR DESCRIPTION
Fixes `Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode` when trying to run a live reload build.