### PR TITLE
Fix/windows paths

### DIFF
--- a/lib/targets/android/tasks/boot-emulator.js
+++ b/lib/targets/android/tasks/boot-emulator.js
@@ -1,10 +1,7 @@
 const spawn           = require('../../../utils/spawn');
-const path            = require('path');
 const RSVP            = require('rsvp');
 const getEmState      = require('./get-emulator-state');
-
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const emulatorPath    = path.join(sdkPath, 'tools', 'emulator');
+const sdkPaths        = require('../utils/sdk-paths');
 
 const pollDevices = function(deferred, emulator) {
   getEmState().then((emState) => {
@@ -20,6 +17,8 @@ const pollDevices = function(deferred, emulator) {
 
 module.exports = function(emulator) {
   let deferred = RSVP.defer();
+  let emulatorPath = sdkPaths().emulator;
+
   let boot = [
     emulatorPath,
     ['-avd', emulator.name]

--- a/lib/targets/android/tasks/get-emulator-state.js
+++ b/lib/targets/android/tasks/get-emulator-state.js
@@ -1,13 +1,10 @@
 const spawn           = require('../../../utils/spawn');
-
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
-
+const sdkPaths        = require('../utils/sdk-paths');
 const RSVP            = require('rsvp');
 
 module.exports = function() {
   let defer = RSVP.defer();
+  let adbPath = sdkPaths().adb;
 
   let emulatorState = [
     adbPath,

--- a/lib/targets/android/tasks/install-app.js
+++ b/lib/targets/android/tasks/install-app.js
@@ -1,10 +1,9 @@
 const spawn           = require('../../../utils/spawn');
-
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
+const sdkPaths        = require('../utils/sdk-paths');
 
 module.exports = function(apkPath) {
+  let adbPath = sdkPaths().adb;
+
   let install = [
     adbPath,
     ['-e', 'install', '-r', apkPath]

--- a/lib/targets/android/tasks/kill-emulator.js
+++ b/lib/targets/android/tasks/kill-emulator.js
@@ -1,9 +1,9 @@
 const spawn           = require('../../../utils/spawn');
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
+const sdkPaths        = require('../utils/sdk-paths');
 
 module.exports = function(emulatorId) {
+  let adbPath = sdkPaths().adb;
+
   let kill = [
     adbPath,
     ['-s', emulatorId, 'emu', 'kill']

--- a/lib/targets/android/tasks/launch-app.js
+++ b/lib/targets/android/tasks/launch-app.js
@@ -1,13 +1,11 @@
 const spawn           = require('../../../utils/spawn');
-
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
-
+const sdkPaths        = require('../utils/sdk-paths');
 const RSVP            = require('rsvp');
 
 module.exports = function(packageName) {
   let defer = RSVP.defer();
+  let adbPath = sdkPaths().adb;
+
 
   let launch = [
     adbPath,

--- a/lib/targets/android/tasks/list-emulators.js
+++ b/lib/targets/android/tasks/list-emulators.js
@@ -1,10 +1,10 @@
 const Emulator        = require('../../../objects/emulator');
 const spawn           = require('../../../utils/spawn');
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const emulatorPath    = path.join(sdkPath, 'tools', 'emulator');
+const sdkPaths        = require('../utils/sdk-paths');
 
 module.exports = function() {
+  let emulatorPath = sdkPaths().emulator;
+
   let list = [
     emulatorPath,
     ['emulator', '-list-avds']

--- a/lib/targets/android/tasks/list-running-emulators.js
+++ b/lib/targets/android/tasks/list-running-emulators.js
@@ -1,9 +1,9 @@
 const spawn           = require('../../../utils/spawn');
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
+const sdkPaths        = require('../utils/sdk-paths');
 
 module.exports = function() {
+  let adbPath = sdkPaths().adb;
+
   let devices = [
     adbPath,
     ['devices', '-l']

--- a/lib/targets/android/utils/sdk-paths.js
+++ b/lib/targets/android/utils/sdk-paths.js
@@ -1,0 +1,16 @@
+const path            = require('path');
+const getOS           = require('../../../utils/get-os');
+
+module.exports = function() {
+  let platform = getOS();
+
+  if (platform === 'darwin') {
+    let sdkRoot = path.join(process.env['HOME'], 'Library', 'Android', 'sdk');
+    return {
+      adb: path.join(sdkRoot, 'platform-tools', 'adb'),
+      emulator: path.join(sdkRoot, 'tools', 'emulator')
+    }
+  } else if (platform === 'win32') {
+    //TODO
+  }
+};

--- a/lib/utils/get-os.js
+++ b/lib/utils/get-os.js
@@ -1,0 +1,5 @@
+const os              = require('os');
+
+module.exports = function() {
+  return os.platform();
+};

--- a/node-tests/unit/targets/android/tasks/boot-emulator-test.js
+++ b/node-tests/unit/targets/android/tasks/boot-emulator-test.js
@@ -1,11 +1,15 @@
 const td              = require('testdouble');
 const expect          = require('../../../../helpers/expect');
 
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const emulatorPath    = path.join(sdkPath, 'tools', 'emulator');
-
 describe('Android Boot Emulator', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        emulator: 'emulatorPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -26,7 +30,7 @@ describe('Android Boot Emulator', function() {
     let bootEm = require('../../../../../lib/targets/android/tasks/boot-emulator');
 
     return bootEm({name: 'fake-emulator'}).then(function() {
-      expect(spawnProps.cmd).to.equal(emulatorPath);
+      expect(spawnProps.cmd).to.equal('emulatorPath');
       expect(spawnProps.args).to.deep.equal(['-avd', 'fake-emulator']);
     });
   });

--- a/node-tests/unit/targets/android/tasks/get-emulator-state-test.js
+++ b/node-tests/unit/targets/android/tasks/get-emulator-state-test.js
@@ -1,10 +1,15 @@
 const td              = require('testdouble');
 const expect          = require('../../../../helpers/expect');
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
 
 describe('Android Eulator State', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        adb: 'adbPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -22,7 +27,7 @@ describe('Android Eulator State', function() {
     let emState = require('../../../../../lib/targets/android/tasks/get-emulator-state');
 
     return emState().then(function() {
-      expect(spawnProps.cmd).to.equal(adbPath);
+      expect(spawnProps.cmd).to.equal('adbPath');
       expect(spawnProps.args).to.deep.equal([
         'shell',
         'getprop',

--- a/node-tests/unit/targets/android/tasks/install-app-test.js
+++ b/node-tests/unit/targets/android/tasks/install-app-test.js
@@ -1,10 +1,14 @@
 const td              = require('testdouble');
 
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
-
 describe('Android Install App', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        adb: 'adbPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -16,7 +20,7 @@ describe('Android Install App', function() {
     installApp('apk-path');
 
     td.verify(spawnDouble(
-      adbPath,
+      'adbPath',
       [
         '-e',
         'install',

--- a/node-tests/unit/targets/android/tasks/kill-emulator-test.js
+++ b/node-tests/unit/targets/android/tasks/kill-emulator-test.js
@@ -1,10 +1,14 @@
 const td              = require('testdouble');
 
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
-
 describe('Android Kill Emulator', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        adb: 'adbPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -16,7 +20,7 @@ describe('Android Kill Emulator', function() {
     killEmulator('emulator-fake');
 
     td.verify(spawnDouble(
-      adbPath,
+      'adbPath',
       [
         '-s',
         'emulator-fake',

--- a/node-tests/unit/targets/android/tasks/launch-app-test.js
+++ b/node-tests/unit/targets/android/tasks/launch-app-test.js
@@ -1,10 +1,15 @@
 const td              = require('testdouble');
 const expect          = require('../../../../helpers/expect');
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
 
 describe('Android LaunchApp', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        adb: 'adbPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -21,7 +26,7 @@ describe('Android LaunchApp', function() {
     let launchApp = require('../../../../../lib/targets/android/tasks/launch-app');
 
     return launchApp('io.corber.project').then(function() {
-      expect(spawnProps.cmd).to.equal(adbPath);
+      expect(spawnProps.cmd).to.equal('adbPath');
       expect(spawnProps.args).to.deep.equal([
         'shell',
         'monkey',

--- a/node-tests/unit/targets/android/tasks/list-emulators-test.js
+++ b/node-tests/unit/targets/android/tasks/list-emulators-test.js
@@ -5,11 +5,15 @@ const AndroidEm       = require('../../../../../lib/objects/emulator');
 
 const emList          = 'Nexus_5X_API_27\nPixel_2_API_27';
 
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const emPath          = path.join(sdkPath, 'tools', 'emulator');
-
 describe('Android List Emulators', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        emulator: 'emulatorPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -26,7 +30,7 @@ describe('Android List Emulators', function() {
     let listEms = require('../../../../../lib/targets/android/tasks/list-emulators');
 
     return listEms().then(function() {
-      expect(spawnProps.cmd).to.equal(emPath);
+      expect(spawnProps.cmd).to.equal('emulatorPath');
       expect(spawnProps.args).to.deep.equal(['emulator', '-list-avds']);
     });
   });

--- a/node-tests/unit/targets/android/tasks/list-running-emulators-test.js
+++ b/node-tests/unit/targets/android/tasks/list-running-emulators-test.js
@@ -4,11 +4,15 @@ const Promise         = require('rsvp').Promise;
 
 const emList          = 'emulator-5554          device product:sdk_gphone_x86 model:Android_SDK_built_for_x86 device:generic_x86 transport_id:26';
 
-const path            = require('path');
-const sdkPath         = path.join(process.env['HOME'], 'Library/Android/sdk');
-const adbPath         = path.join(sdkPath, 'platform-tools', 'adb');
-
 describe('Android List Running Emulators', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/android/utils/sdk-paths', function() {
+      return {
+        adb: 'adbPath'
+      }
+    });
+  });
+
   afterEach(function() {
     td.reset();
   });
@@ -25,7 +29,7 @@ describe('Android List Running Emulators', function() {
     let listRunning = require('../../../../../lib/targets/android/tasks/list-running-emulators');
 
     return listRunning().then(function() {
-      expect(spawnProps.cmd).to.equal(adbPath);
+      expect(spawnProps.cmd).to.equal('adbPath');
       expect(spawnProps.args).to.deep.equal(['devices', '-l']);
     });
   });

--- a/node-tests/unit/targets/android/utils/sdk-paths-test.js
+++ b/node-tests/unit/targets/android/utils/sdk-paths-test.js
@@ -1,0 +1,37 @@
+/* global xit */
+const td              = require('testdouble');
+const path            = require('path');
+const expect          = require('../../../../helpers/expect');
+
+describe('Android sdk paths util', function() {
+  afterEach(function() {
+    td.reset();
+  });
+
+  context('darwin', function() {
+    beforeEach(function() {
+      td.replace('../../../../../lib/utils/get-os', function() {
+        return 'darwin';
+      });
+    });
+
+    it('returns a hash with adb & emulator', function() {
+      let sdkPaths = require('../../../../../lib/targets/android/utils/sdk-paths');
+      let sdkRoot = path.join(process.env['HOME'], 'Library', 'Android', 'sdk');
+
+      let paths = sdkPaths();
+
+      expect(paths).to.deep.equal({
+        adb: path.join(sdkRoot, 'platform-tools', 'adb'),
+        emulator: path.join(sdkRoot, 'tools', 'emulator')
+      });
+    });
+  });
+
+  context('win32', function() {
+    xit('returns a hash with adb & emulator', function() {
+    });
+  });
+});
+
+


### PR DESCRIPTION
This PR starts to abstract android SDK paths. There is further work to support/check on windows, and this PR does not complete support for the _start_ command on Windows. That will be completed in #453.

This PR takes the work far enough to hotfix windows android builds per  #457 