### PR TITLE
fix(cli): return promises & exit correctly on all commands

### DIFF
--- a/bin/corber
+++ b/bin/corber
@@ -10,6 +10,7 @@ const resolve               = require('resolve');
 const path                  = require('path');
 const requireAsHash         = require('ember-cli/lib/utilities/require-as-hash');
 const willInterruptProcess  = require('ember-cli/lib/utilities/will-interrupt-process');
+const exit                  = require('exit');
 
 // `process` should be captured before we require any libraries which
 // may use `process.exit` work arounds for async cleanup.
@@ -53,4 +54,15 @@ let environment = {
   settings: {}
 }
 
-return cli.run(environment);
+let promise = cli.run(environment);
+
+promise.then(function(result) {
+  let exitCode = typeof result === 'object'  && result.exitCode ? result.exitCode : 0;
+  exit(exitCode);
+});
+promise.catch((error) => {
+  let exitCode = typeof error === 'object'  && result.exitCode ? result.exitCode : 1;
+  exit(exitCode);
+});
+
+return promise;

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -6,6 +6,7 @@ const logger           = require('../utils/logger');
 const requireTarget    = require('../utils/require-target');
 const requireFramework = require('../utils/require-framework');
 const path             = require('path');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'build',
@@ -80,34 +81,38 @@ module.exports = Command.extend({
 
     logger.info('corber: Building app');
 
-    return hook.run('beforeBuild', options)
-      .then(() => framework.validateBuild(options))
-      .then(() => cordovaTarget.validateBuild(options.skipCordovaBuild))
-      .then(() => {
-        if (options.skipFrameworkBuild !== true) {
-          return framework.build(options);
-        }
-      })
-      .then(() => {
-        if (
-          options.skipFrameworkBuild !== true ||
-          options.addCordovaJs === true
-        ) {
-          return addCordovaJS.run();
-        }
-      })
-      .then(() => {
-        if (options.skipCordovaBuild !== true) {
-          return cordovaTarget.build();
-        }
-      })
-      .then(() => hook.run('afterBuild', options))
-      .then(() => lint.run())
-      .then(function() {
-        logger.success('corber project built');
-      })
-      .catch(function(e) {
-        logger.error(e);
-      });
+    return new Promise((resolve, reject) => {
+      hook.run('beforeBuild', options)
+        .then(() => framework.validateBuild(options))
+        .then(() => cordovaTarget.validateBuild(options.skipCordovaBuild))
+        .then(() => {
+          if (options.skipFrameworkBuild !== true) {
+            return framework.build(options);
+          }
+        })
+        .then(() => {
+          if (
+            options.skipFrameworkBuild !== true ||
+            options.addCordovaJs === true
+          ) {
+            return addCordovaJS.run();
+          }
+        })
+        .then(() => {
+          if (options.skipCordovaBuild !== true) {
+            return cordovaTarget.build();
+          }
+        })
+        .then(() => hook.run('afterBuild', options))
+        .then(() => lint.run())
+        .then(function() {
+          logger.success('corber project built');
+          resolve();
+        })
+        .catch(function(e) {
+          logger.error(e);
+          reject(e);
+        });
+    });
   }
 });

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -3,6 +3,7 @@ const CreateProject   = require('../tasks/create-project');
 const PlatformTask    = require('../targets/cordova/tasks/platform');
 const logger          = require('../utils/logger');
 const RSVP            = require('rsvp');
+const Promise         = RSVP.Promise;
 
 module.exports = Command.extend({
   name: 'init',
@@ -56,21 +57,23 @@ module.exports = Command.extend({
     });
 
 
-    return create.run().then(() => {
-      if (options.platform) {
-        let platforms = this.getPlatforms(options.platform);
-        this.installPlatforms(platforms);
-      } else {
-        return this.promptPlatform().then((selected) => {
-          if (selected.platforms[0] === 'none') {
-            logger.success('Project created with no platforms');
-          } else {
-            return this.installPlatforms(selected.platforms).then(() => {
-              logger.success('Project created');
-            });
-          }
-        });
-      }
+    return new Promise((resolve, reject) => {
+      create.run().then(() => {
+        if (options.platform) {
+          let platforms = this.getPlatforms(options.platform);
+          return this.installPlatforms(platforms);
+        } else {
+          return this.promptPlatform().then((selected) => {
+            if (selected.platforms[0] === 'none') {
+              logger.success('Project created with no platforms');
+            } else {
+              return this.installPlatforms(selected.platforms).then(() => {
+                logger.success('Project created');
+              });
+            }
+          });
+        }
+      }).then(resolve).catch(reject);
     });
   }
 });

--- a/lib/commands/make-icons.js
+++ b/lib/commands/make-icons.js
@@ -5,6 +5,7 @@ const logger           = require('../utils/logger');
 
 const includes         = require('lodash').includes;
 const pull             = require('lodash').pull;
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'make-icons',
@@ -50,14 +51,18 @@ module.exports = Command.extend({
     logger.info('corber: Generating icons for ' + options.platform.join(', '));
     /* eslint-enable max-len */
 
-    return iconTask({
-      source: options.source,
-      platforms: options.platform,
-      projectPath: 'corber/cordova'
-    }).then(function() {
-      logger.success('corber: icons generated');
-    }).catch(function(err) {
-      logger.error(err);
+    return new Promise((resolve, reject) => {
+      iconTask({
+        source: options.source,
+        platforms: options.platform,
+        projectPath: 'corber/cordova'
+      }).then(function() {
+        logger.success('corber: icons generated');
+        resolve();
+      }).catch(function(err) {
+        logger.error(err);
+        reject(err);
+      });
     });
   }
 });

--- a/lib/commands/make-splashes.js
+++ b/lib/commands/make-splashes.js
@@ -5,6 +5,7 @@ const logger           = require('../utils/logger');
 
 const includes         = require('lodash').includes;
 const pull             = require('lodash').pull;
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'make-splashes',
@@ -48,14 +49,18 @@ module.exports = Command.extend({
     logger.info('corber: Generating splashes for ' + options.platform.join(', '));
     /* eslint-enable max-len */
 
-    return splashTask({
-      source: options.source,
-      platforms: options.platform,
-      projectPath: 'corber/cordova'
-    }).then(function() {
-      logger.success('corber: splashes generated');
-    }).catch(function(err) {
-      logger.error(err);
+    return new Promise((resolve, reject) => {
+      splashTask({
+        source: options.source,
+        platforms: options.platform,
+        projectPath: 'corber/cordova'
+      }).then(function() {
+        logger.success('corber: splashes generated');
+        resolve();
+      }).catch(function(err) {
+        logger.error(err);
+        reject(err);
+      });
     });
   }
 });

--- a/lib/commands/open.js
+++ b/lib/commands/open.js
@@ -1,6 +1,7 @@
 const Command          = require('./-command');
 const Open             = require('../targets/cordova/tasks/open-app');
 const logger           = require('../utils/logger');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'open',
@@ -23,8 +24,11 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return open.run().catch(function(err) {
-      logger.error(err);
+    return new Promise((resolve, reject) => {
+      open.run().then(resolve).catch(function(err) {
+        logger.error(err);
+        reject(err);
+      });
     });
   }
 });

--- a/lib/commands/platform.js
+++ b/lib/commands/platform.js
@@ -2,6 +2,7 @@ const Command          = require('./-command');
 const SanitizeArgs     = require('../targets/cordova/validators/addon-args');
 const PlatformTask     = require('../targets/cordova/tasks/platform');
 const logger           = require('../utils/logger');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'platform',
@@ -31,14 +32,17 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return cordovaArgValidator.run().then((validated) => {
-      logger.info(
-        'Preparing to ' + validated.action + ' platform ' + rawArgs
-      );
+    return new Promise((resolve, reject) => {
+      cordovaArgValidator.run().then((validated) => {
+        logger.info(
+          'Preparing to ' + validated.action + ' platform ' + rawArgs
+        );
 
-      return platform.run(validated.action, validated.name, options);
-    }).catch(function(err) {
-      logger.error(err);
+        return platform.run(validated.action, validated.name, options);
+      }).then(resolve).catch(function(err) {
+        logger.error(err);
+        reject();
+      });
     });
   }
 });

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -5,6 +5,7 @@ const Command          = require('./-command');
 const CordovaRaw       = require('../targets/cordova/tasks/raw');
 const SanitizeArgs     = require('../targets/cordova/validators/addon-args');
 const logger           = require('../utils/logger');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'plugin',
@@ -37,8 +38,8 @@ module.exports = Command.extend({
       api: 'plugins'
     });
 
-    return cordovaArgSanitizer.run()
-      .then(function(validated) {
+    return new Promise((resolve, reject) => {
+      cordovaArgSanitizer.run().then(function(validated) {
         logger.info(
           'Preparing to ' + validated.action + ' plugins ' + rawArgs
         );
@@ -54,9 +55,10 @@ module.exports = Command.extend({
           cli_variables: validated.varOpts,
           fetch: true
         });
-
-      }).catch(function(err) {
+      }).then(resolve).catch((err) => {
         logger.error(err);
+        reject(err);
       });
+    });
   }
 });

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -2,6 +2,7 @@ const Command          = require('./-command');
 const Prepare          = require('../targets/cordova/tasks/prepare');
 const Hook             = require('../tasks/run-hook');
 const logger           = require('../utils/logger');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'prepare',
@@ -23,11 +24,15 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return hook.run('beforePrepare', options)
-      .then(() => prepare.run())
-      .then(() => hook.run('afterPrepare', options))
-      .catch(function(err) {
-        logger.error(err);
-      });
+    return new Promise((resolve, reject) => {
+      hook.run('beforePrepare', options)
+        .then(() => prepare.run())
+        .then(() => hook.run('afterPrepare', options))
+        .then(resolve)
+        .catch(function(err) {
+          logger.error(err);
+          reject(err);
+        });
+    })
   }
 });

--- a/lib/commands/proxy.js
+++ b/lib/commands/proxy.js
@@ -2,6 +2,7 @@ const Command          = require('./-command');
 const Bash             = require('../tasks/bash');
 const cordovaPath      = require('../targets/cordova/utils/get-path');
 const logger           = require('../utils/logger');
+const Promise          = require('rsvp').Promise;
 
 let ValidateCordova = require('../targets/cordova/validators/is-installed');
 
@@ -52,21 +53,24 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return isInstalled.run().then(() => {
-      let joinedArgs = rawArgs.join(' ');
-      let cdvCommand = 'cordova ' + joinedArgs;
+    return new Promise((resolve, reject) => {
+      isInstalled.run().then(() => {
+        let joinedArgs = rawArgs.join(' ');
+        let cdvCommand = 'cordova ' + joinedArgs;
 
-      let msg = 'Running \'cordova ' + joinedArgs + '\'';
-      logger.success(msg);
+        let msg = 'Running \'cordova ' + joinedArgs + '\'';
+        logger.success(msg);
 
-      return new Bash({
-        command: cdvCommand,
-        options: {
-          cwd: cordovaPath(this.project)
-        }
-      }).run();
-    }).catch(function(e) {
-      logger.error(e);
+        return new Bash({
+          command: cdvCommand,
+          options: {
+            cwd: cordovaPath(this.project)
+          }
+        }).run();
+      }).then(resolve).catch(function(e) {
+        logger.error(e);
+        reject(e);
+      });
     });
   }
 });

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -5,6 +5,7 @@ const editXml         = require('../targets/cordova/utils/edit-xml');
 const getNetworkIp    = require('../utils/get-network-ip');
 const requireTarget   = require('../utils/require-target');
 const requireFramework = require('../utils/require-framework');
+const Promise          = require('rsvp').Promise;
 
 const CreateLiveReloadShell   = require('../tasks/create-livereload-shell');
 
@@ -82,24 +83,28 @@ module.exports = Command.extend({
     let project = this.project;
     let ui = this.ui;
 
-    return editXml.addNavigation(project, reloadUrl)
-      .then(() => hook.run('beforeBuild', opts))
-      .then(() => cordovaTarget.validateServe())
-      .then(() => framework.validateServe(opts))
-      .then(() => setupLivereload.run(reloadUrl))
-      .then(function() {
-        if (opts.skipCordovaBuild !== true) {
-          return cordovaTarget.build();
-        }
-      })
-      .then(() => hook.run('afterBuild', opts))
-      .then(function() {
-        if (opts.skipFrameworkBuild !== true) {
-          return framework.serve(opts, ui);
-        }
-      })
-    .catch(function(e) {
-      logger.error(e);
+    return new Promise((resolve, reject) => {
+      editXml.addNavigation(project, reloadUrl)
+        .then(() => hook.run('beforeBuild', opts))
+        .then(() => cordovaTarget.validateServe())
+        .then(() => framework.validateServe(opts))
+        .then(() => setupLivereload.run(reloadUrl))
+        .then(function() {
+          if (opts.skipCordovaBuild !== true) {
+            return cordovaTarget.build();
+          }
+        })
+        .then(() => hook.run('afterBuild', opts))
+        .then(function() {
+          if (opts.skipFrameworkBuild !== true) {
+            return framework.serve(opts, ui);
+          }
+        })
+        .then(resolve)
+        .catch(function(e) {
+          logger.error(e);
+          reject(e);
+        });
     });
   }
 });

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -6,8 +6,7 @@ const CordovaRaw       = require('../targets/cordova/tasks/raw');
 const editXml          = require('../targets/cordova/utils/edit-xml');
 const getNetworkIp     = require('../utils/get-network-ip');
 const requireFramework = require('../utils/require-framework');
-const RSVP             = require('rsvp');
-const Promise          = RSVP.Promise;
+const Promise          = require('rsvp').Promise;
 const flatten          = require('lodash').flatten;
 
 const listAndroidEms   = require('../targets/android/tasks/list-emulators');
@@ -53,7 +52,7 @@ module.exports = Command.extend({
       getEmulators.push(listIOSEms());
     }
 
-    return RSVP.all(getEmulators).then((emulators) => {
+    return Promise.all(getEmulators).then((emulators) => {
       emulators = flatten(emulators);
       if (opts.emulator === '') {
         let promptOpts = {
@@ -137,16 +136,19 @@ module.exports = Command.extend({
         project: this.project
       });
 
-      return framework.validateServe(opts)
-        .then(() => editXml.addNavigation(this.project, reloadUrl))
-        .then(() => createLivereloadShell.run(reloadUrl))
-        .then(() => prepare.run({ platforms: [emulator.platform] }))
-        .then(() => hook.run('beforeBuild'))
-        .then(() => cdvTarget.validateServe())
-        .then(() => platformTarget.build())
-        .then(() => hook.run('afterBuild'))
-        .then(() => platformTarget.run())
-        .then(() => framework.serve(opts, this.ui));
+      return new Promise((resolve, reject) => {
+        framework.validateServe(opts)
+          .then(() => editXml.addNavigation(this.project, reloadUrl))
+          .then(() => createLivereloadShell.run(reloadUrl))
+          .then(() => prepare.run({ platforms: [emulator.platform] }))
+          .then(() => hook.run('beforeBuild'))
+          .then(() => cdvTarget.validateServe())
+          .then(() => platformTarget.build())
+          .then(() => hook.run('afterBuild'))
+          .then(() => platformTarget.run())
+          .then(() => framework.serve(opts, this.ui))
+          .then(resolve).catch(reject);
+      });
     });
   }
 });

--- a/lib/frameworks/ember/tasks/serve.js
+++ b/lib/frameworks/ember/tasks/serve.js
@@ -11,6 +11,7 @@
 const LiveReloadServer = require('ember-cli/lib/tasks/server/livereload-server');
 const ExpressServer    = require('ember-cli/lib/tasks/server/express-server');
 const RSVP             = require('rsvp');
+const Promise          = RSVP.Promise;
 const Task             = require('ember-cli/lib/models/task');
 const Watcher          = require('ember-cli/lib/models/watcher');
 const Builder          = require('ember-cli/lib/models/builder');
@@ -97,16 +98,18 @@ module.exports = Task.extend({
 
     // h/t ember-cli, hang until user exit
     this._runDeferred = RSVP.defer();
-    return RSVP.Promise.all([
-      liveReloadServer.start(options),
-      expressServer.start(options),
-      watcher.then()
-    ]).then(() => {
-      if (options.liveReload) {
-        logger.success('corber: Device LiveReload is enabled');
-      }
+    return new Promise((resolve, reject) => {
+      Promise.all([
+        liveReloadServer.start(options),
+        expressServer.start(options),
+        watcher.then()
+      ]).then(() => {
+        if (options.liveReload) {
+          logger.success('corber: Device LiveReload is enabled');
+        }
 
-      return this._runDeferred.promise;
+        return this._runDeferred.promise;
+      }).then(resolve).catch(reject);
     });
   },
 

--- a/lib/targets/cordova/tasks/raw.js
+++ b/lib/targets/cordova/tasks/raw.js
@@ -1,6 +1,5 @@
 const Task            = require('../../../tasks/-task');
-const RSVP            = require('rsvp');
-const Promise         = RSVP.Promise;
+const Promise         = require('rsvp').Promise;
 const cordovaPath     = require('../utils/get-path');
 const cordovaLib      = require('cordova-lib');
 const cordovaProj     = cordovaLib.cordova;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -31,7 +31,9 @@ module.exports = {
   },
 
   error(content) {
-    throw new ECError(content);
+    let error = new ECError(content);
+    console.log(chalk.red(error));
+    return error;
   },
 
   getLogLevel() {

--- a/lib/utils/parse-xml.js
+++ b/lib/utils/parse-xml.js
@@ -5,13 +5,14 @@ const fsUtils          = require('./fs-utils');
 const logger           = require('./logger');
 
 module.exports = function parseXML(xmlPath) {
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
     let contents = fsUtils.readSync(xmlPath, { encoding: 'utf8' });
     let parser = new xml2js.Parser();
 
     parser.parseString(contents, function (err, result) {
       if (err) {
         logger.error(err);
+        return reject(err);
       }
 
       if (result) {

--- a/lib/utils/require-framework.js
+++ b/lib/utils/require-framework.js
@@ -9,6 +9,7 @@ module.exports = function(project) {
     ));
   } catch (err) {
     logger.error('No corber/config/framework.js found');
+    throw err;
   }
 
   let framework = new Framework({


### PR DESCRIPTION
This PR resolves #461, on both Windows 10 and Linux (running on CircleCI). I could not test other environments.

The solution was basically lifted from here:
https://github.com/ember-cli/ember-cli/blob/master/bin/ember

There were two issues, that are probably related:

- The `logger.error()` method used to throw an error. This, for whatever reason, did not result in an appropriate exit.
- Even when successfull, it would sometimes not exit the process.

This PR slightly refactors all commands to return dedicated RSVP.Promises. The `logger.error` method has been changed to only output the error, not throw it. And the corber executable itself has been adapted (based on ember-cli's exectuable) to exit the process on both success and failure.