### PR TITLE
Start command platforms, devices, and emulators fixes

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -67,9 +67,9 @@ module.exports = Command.extend({
       }, []);
 
       if (devices.length === 0) {
-        logger.error('No emulators found. You must install an iOS or Android '
-          + 'emulator before running "corber start".');
-        return Promise.reject();
+        throw(`
+          No emulators or devices found. You must connect a device or install
+          an iOS or Android emulator before running "corber start".`);
       }
 
       if (opts.emulator === '') {
@@ -107,9 +107,9 @@ module.exports = Command.extend({
   },
 
   validatePlatform(installedPlatforms, targetPlatform) {
-    //If no target platfor mshow all installed platforms
+    // only perform check when `targetPlatform` is specified
     if (targetPlatform && !installedPlatforms.includes(targetPlatform)) {
-      logger.error(`
+      throw (`
         You are passing platform=${targetPlatform} which is not installed.
         Try running corber platform add ${targetPlatform}`);
     }
@@ -123,72 +123,75 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return cdvTarget.getInstalledPlatforms().then((platforms) => {
-      if (platforms.length === 0) {
-        logger.error('No platforms installed.');
-        return Promise.reject();
-      }
+    return new Promise((resolve, reject) => {
+      cdvTarget.getInstalledPlatforms().then((platforms) => {
+        if (platforms.length === 0) {
+          throw(`
+            No platforms installed. Install a platform using
 
-      this.validatePlatform(platforms, opts.platform);
-      return this.selectDevice(opts, platforms);
-    }).then((device) => {
-      //supports webpack addon
-      this.project.targetIsCordova = true;
-      this.project.CORBER_PLATFORM = device.platform;
-      this.project.targetIsCordovaLivereload = true;
+              corber platform add <ios|android>
 
-      cdvTarget.platform = device.platform;
+            before running "corber start".`);
+        }
 
-      let platformTarget;
-      if (device.platform === 'ios') {
-        platformTarget = new IOSTarget({
-          device: device,
+        this.validatePlatform(platforms, opts.platform);
+        return this.selectDevice(opts, platforms);
+      }).then((device) => {
+        //supports webpack addon
+        this.project.targetIsCordova = true;
+        this.project.CORBER_PLATFORM = device.platform;
+        this.project.targetIsCordovaLivereload = true;
+
+        cdvTarget.platform = device.platform;
+
+        let platformTarget;
+        if (device.platform === 'ios') {
+          platformTarget = new IOSTarget({
+            device: device,
+            project: this.project
+          });
+        } else if (device.platform === 'android') {
+          platformTarget = new AndroidTarget({
+            device: device,
+            project: this.project
+          });
+        }
+
+        let framework = requireFramework(this.project);
+        let reloadUrl = this.getReloadUrl(opts.port, opts.reloadUrl, framework);
+
+        let createLivereloadShell = new CreateLiveReloadShell({
           project: this.project
         });
-      } else if (device.platform === 'android') {
-        platformTarget = new AndroidTarget({
-          device: device,
+
+        let prepare = new CordovaRaw({
+          project: this.project,
+          api: 'prepare'
+        });
+
+        let hook = new Hook({
           project: this.project
         });
-      }
 
-      let framework = requireFramework(this.project);
-      let reloadUrl = this.getReloadUrl(opts.port, opts.reloadUrl, framework);
-
-      let createLivereloadShell = new CreateLiveReloadShell({
-        project: this.project
-      });
-
-      let prepare = new CordovaRaw({
-        project: this.project,
-        api: 'prepare'
-      });
-
-      let hook = new Hook({
-        project: this.project
-      });
-
-      return new Promise((resolve, reject) => {
-        hook.run('beforeBuild')
-          .then(() => editXml.addNavigation(this.project, reloadUrl))
-          .then(() => cdvTarget.validateServe())
-          .then(() => framework.validateServe(opts))
-          .then(() => createLivereloadShell.run(reloadUrl))
-          .then(() => prepare.run({ platforms: [device.platform] }))
-          .then(function() {
-            if (opts.skipCordovaBuild !== true) {
-              return platformTarget.build();
-            }
-          })
-          .then(() => hook.run('afterBuild'))
-          .then(() => platformTarget.run())
-          .then(() => {
-            if (opts.skipFrameworkBuild !== true) {
-              return framework.serve(opts, this.ui);
-            }
-          })
-          .then(resolve).catch(reject);
-      });
+        return hook.run('beforeBuild');
+      }).then(() => editXml.addNavigation(this.project, reloadUrl))
+        .then(() => cdvTarget.validateServe())
+        .then(() => framework.validateServe(opts))
+        .then(() => createLivereloadShell.run(reloadUrl))
+        .then(() => prepare.run({ platforms: [device.platform] }))
+        .then(function() {
+          if (opts.skipCordovaBuild !== true) {
+            return platformTarget.build();
+          }
+        })
+        .then(() => hook.run('afterBuild'))
+        .then(() => platformTarget.run())
+        .then(() => {
+          if (opts.skipFrameworkBuild !== true) {
+            return framework.serve(opts, this.ui);
+          }
+        })
+      .then(resolve).catch(reject);
     });
   }
 });

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -8,7 +8,6 @@ const getNetworkIp     = require('../utils/get-network-ip');
 const requireFramework = require('../utils/require-framework');
 const RSVP             = require('rsvp');
 const Promise          = RSVP.Promise;
-const flatten          = require('lodash').flatten;
 
 const listAndroidEms   = require('../targets/android/tasks/list-emulators');
 const listAndroidDevices = require('../targets/android/tasks/list-devices');
@@ -59,8 +58,20 @@ module.exports = Command.extend({
       foundDevices.push(listIOSEms());
     }
 
-    return RSVP.all(foundDevices).then((devices) => {
-      devices = flatten(devices);
+    return RSVP.allSettled(foundDevices).then((results) => {
+      let devices = results.reduce((arr, result) => {
+        if (result.state === 'fulfilled') {
+          return arr.concat(result.value);
+        }
+        return arr;
+      }, []);
+
+      if (devices.length === 0) {
+        logger.error('No emulators found. You must install an iOS or Android '
+          + 'emulator before running "corber start".');
+        return Promise.reject();
+      }
+
       if (opts.emulator === '') {
         let promptOpts = {
           type: 'list',
@@ -112,10 +123,15 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    let installedPlatforms = cdvTarget.installedPlatforms();
-    this.validatePlatform(installedPlatforms, opts.platform);
+    return cdvTarget.getInstalledPlatforms().then((platforms) => {
+      if (platforms.length === 0) {
+        logger.error('No platforms installed.');
+        return Promise.reject();
+      }
 
-    return this.selectDevice(opts, installedPlatforms).then((device) => {
+      this.validatePlatform(platforms, opts.platform);
+      return this.selectDevice(opts, platforms);
+    }).then((device) => {
       //supports webpack addon
       this.project.targetIsCordova = true;
       this.project.CORBER_PLATFORM = device.platform;

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -67,9 +67,9 @@ module.exports = Command.extend({
       }, []);
 
       if (devices.length === 0) {
-        throw(`
+        throw `
           No emulators or devices found. You must connect a device or install
-          an iOS or Android emulator before running "corber start".`);
+          an iOS or Android emulator before running "corber start".`;
       }
 
       if (opts.emulator === '') {
@@ -109,9 +109,9 @@ module.exports = Command.extend({
   validatePlatform(installedPlatforms, targetPlatform) {
     // only perform check when `targetPlatform` is specified
     if (targetPlatform && !installedPlatforms.includes(targetPlatform)) {
-      throw (`
+      throw `
         You are passing platform=${targetPlatform} which is not installed.
-        Try running corber platform add ${targetPlatform}`);
+        Try running corber platform add ${targetPlatform}`;
     }
   },
 
@@ -126,12 +126,12 @@ module.exports = Command.extend({
     return new Promise((resolve, reject) => {
       cdvTarget.getInstalledPlatforms().then((platforms) => {
         if (platforms.length === 0) {
-          throw(`
+          throw `
             No platforms installed. Install a platform using
 
               corber platform add <ios|android>
 
-            before running "corber start".`);
+            before running "corber start".`;
         }
 
         this.validatePlatform(platforms, opts.platform);
@@ -173,25 +173,26 @@ module.exports = Command.extend({
           project: this.project
         });
 
-        return hook.run('beforeBuild');
-      }).then(() => editXml.addNavigation(this.project, reloadUrl))
-        .then(() => cdvTarget.validateServe())
-        .then(() => framework.validateServe(opts))
-        .then(() => createLivereloadShell.run(reloadUrl))
-        .then(() => prepare.run({ platforms: [device.platform] }))
-        .then(function() {
-          if (opts.skipCordovaBuild !== true) {
-            return platformTarget.build();
-          }
-        })
-        .then(() => hook.run('afterBuild'))
-        .then(() => platformTarget.run())
-        .then(() => {
-          if (opts.skipFrameworkBuild !== true) {
-            return framework.serve(opts, this.ui);
-          }
-        })
-      .then(resolve).catch(reject);
+        return hook.run('beforeBuild')
+          .then(() => editXml.addNavigation(this.project, reloadUrl))
+          .then(() => cdvTarget.validateServe())
+          .then(() => framework.validateServe(opts))
+          .then(() => createLivereloadShell.run(reloadUrl))
+          .then(() => prepare.run({ platforms: [device.platform] }))
+          .then(function() {
+            if (opts.skipCordovaBuild !== true) {
+              return platformTarget.build();
+            }
+          })
+          .then(() => hook.run('afterBuild'))
+          .then(() => platformTarget.run())
+          .then(() => {
+            if (opts.skipFrameworkBuild !== true) {
+              return framework.serve(opts, this.ui);
+            }
+          })
+          .then(resolve).catch(reject);
+      });
     });
   }
 });

--- a/lib/targets/android/tasks/list-emulators.js
+++ b/lib/targets/android/tasks/list-emulators.js
@@ -7,7 +7,7 @@ module.exports = function() {
 
   let list = [
     emulatorPath,
-    ['emulator', '-list-avds']
+    ['-list-avds']
   ];
 
   return spawn.apply(null, list).then((found) => {

--- a/lib/targets/cordova/target.js
+++ b/lib/targets/cordova/target.js
@@ -1,12 +1,15 @@
 const CoreObject       = require('core-object');
 const path             = require('path');
+const RSVP             = require('rsvp');
+const Promise          = RSVP.Promise;
 const Build            = require('./tasks/build');
 const runValidators    = require('../../utils/run-validators');
 const ValidatePlugin   = require('./validators/plugin');
 const AllowNavigation  = require('./validators/allow-navigation');
 const fsUtils          = require('../../utils/fs-utils');
 const getPackage       = require('../../utils/get-package');
-const cdvPath          = require('./utils/get-path');
+const parseXml         = require('../../utils/parse-xml');
+const cordovaPath      = require('./utils/get-path');
 
 module.exports = CoreObject.extend({
   platform: undefined,
@@ -46,13 +49,17 @@ module.exports = CoreObject.extend({
     return runValidators(validators);
   },
 
-  installedPlatforms() {
-    let packagePath = path.join(cdvPath(this.project), 'package.json');
+  getInstalledPlatforms() {
+    let packagePath = path.join(cordovaPath(this.project), 'package.json');
     if (fsUtils.existsSync(packagePath)) {
       let packageJSON = getPackage(packagePath);
-      return packageJSON.cordova.platforms;
+      return Promise.resolve(packageJSON.cordova.platforms);
     } else {
-      return [];
+      let cdvPath = cordovaPath(this.project);
+      let configPath = path.join(cdvPath, 'config.xml');
+      return parseXml(configPath).then((json) => {
+        return json.widget.platform.map(p => p.$.name);
+      });
     }
   },
 

--- a/lib/utils/corber-error.js
+++ b/lib/utils/corber-error.js
@@ -2,12 +2,15 @@ const EmberCordovaError = function(content) {
   let message = content.message ? content.message : content;
   let stack = content.stack ? content.stack : (new Error()).stack;
 
-  this.name = 'EmberCordovaError';
-  this.message = 'EmberCordovaError: ' + message;
+  this.name = 'CorberError';
+  this.message = message;
   this.stack = stack.substr(stack.indexOf('\n') + 1);
 };
 
 EmberCordovaError.prototype = Object.create(Error.prototype);
+EmberCordovaError.prototype.toString = function() {
+  return `Corber: ${this.message}`;
+};
 EmberCordovaError.constructor = EmberCordovaError;
 
 module.exports = EmberCordovaError;

--- a/node-tests/unit/commands/start-test.js
+++ b/node-tests/unit/commands/start-test.js
@@ -117,8 +117,8 @@ describe('Start Command', function() {
         return Promise.resolve();
       });
 
-      td.replace(CdvTarget.prototype, 'installedPlatforms', function() {
-        return ['ios'];
+      td.replace(CdvTarget.prototype, 'getInstalledPlatforms', function() {
+        return Promise.resolve(['ios']);
       });
 
       td.replace(LRloadShell.prototype, 'run', function() {

--- a/node-tests/unit/commands/start-test.js
+++ b/node-tests/unit/commands/start-test.js
@@ -311,13 +311,12 @@ describe('Start Command', function() {
     });
 
     it('throws an error when builds are for a platform that is not installed', function() {
-      let logger = td.replace('../../../lib/utils/logger');
-
-
       let start = setupStart();
-      start.validatePlatform(['ios'], 'android');
+      let fn = () => {
+        start.validatePlatform(['ios'], 'android');
+      };
 
-      td.verify(logger.error(td.matchers.anything()));
+      expect(fn).to.throw();
     });
 
     it('passes when builds are for an installed platform', function() {

--- a/node-tests/unit/targets/android/tasks/list-emulators-test.js
+++ b/node-tests/unit/targets/android/tasks/list-emulators-test.js
@@ -31,7 +31,7 @@ describe('Android List Emulators', function() {
 
     return listEms().then(function() {
       expect(spawnProps.cmd).to.equal('emulatorPath');
-      expect(spawnProps.args).to.deep.equal(['emulator', '-list-avds']);
+      expect(spawnProps.args).to.deep.equal(['-list-avds']);
     });
   });
 


### PR DESCRIPTION
- If `corber/cordova/package.json` is not available, uses `config.xml` to determine available platforms.
- Shows an explicit error if no platforms are available.
- Removes extra `emulator` arg from call to list Android emulators.
- Updates promise flow in `run()` method of start command, cleans up error logging.
- Updates `corber-error` object.