### PR TITLE
Feat/signing identity validation

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -111,7 +111,6 @@ module.exports = Command.extend({
         })
         .catch(function(e) {
           logger.error(e);
-          reject(e);
 
           let validation = cordovaTarget.signingIdentityValidation;
           if (validation && validation.failed) {

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -112,6 +112,17 @@ module.exports = Command.extend({
         .catch(function(e) {
           logger.error(e);
           reject(e);
+
+          let validation = cordovaTarget.signingIdentityValidation;
+          if (validation && validation.failed) {
+            logger.warn('No signing identity has been configured for your'
+              + ' xcode project. If you have received an "ARCHIVE FAILED"'
+              + ' message with error code 65, you will need to run'
+              + '"corber open ios" and set your development team'
+              + ' (for automatic signing), or set your'
+              + ` ${validation.buildConfigName} provisioning profile`
+              + ' (for manual signing).');
+          }
         });
     });
   }

--- a/lib/targets/cordova/target.js
+++ b/lib/targets/cordova/target.js
@@ -1,18 +1,19 @@
-const CoreObject       = require('core-object');
-const path             = require('path');
-const RSVP             = require('rsvp');
-const Promise          = RSVP.Promise;
-const Build            = require('./tasks/build');
-const runValidators    = require('../../utils/run-validators');
-const ValidatePlugin   = require('./validators/plugin');
-const AllowNavigation  = require('./validators/allow-navigation');
-const fsUtils          = require('../../utils/fs-utils');
-const getPackage       = require('../../utils/get-package');
-const cordovaPath      = require('./utils/get-path');
+const CoreObject              = require('core-object');
+const { Promise }             = require('rsvp');
+const path                    = require('path');
+const Build                   = require('./tasks/build');
+const ValidatePlugin          = require('./validators/plugin');
+const ValidateSigningIdentity = require('../ios/validators/signing-identity');
+const AllowNavigation         = require('./validators/allow-navigation');
+const cordovaPath             = require('./utils/get-path');
+const fsUtils                 = require('../../utils/fs-utils');
+const getPackage              = require('../../utils/get-package');
+const runValidators           = require('../../utils/run-validators');
 
 module.exports = CoreObject.extend({
   platform: undefined,
   project: undefined,
+  signingIdentityValidation: undefined,
   cordovaOpts: {},
 
   _buildValidators(isServing, skipCordovaBuild = false) {
@@ -24,6 +25,19 @@ module.exports = CoreObject.extend({
         rejectIfUndefined: isServing
       }).run()
     );
+
+    if (this.platform === 'ios') {
+      let validation = new ValidateSigningIdentity({
+        project: this.project,
+        buildConfigName: this.cordovaOpts.release ? 'release' : 'debug',
+        logLevel: 'warn'
+      });
+
+      validators.push(validation.run());
+
+      // build command will inspect this to show message after error code 65
+      this.signingIdentityValidation = validation;
+    }
 
     return validators;
   },

--- a/lib/targets/cordova/utils/get-app-name.js
+++ b/lib/targets/cordova/utils/get-app-name.js
@@ -1,0 +1,7 @@
+const getConfig = require('./get-config');
+
+module.exports = function(project) {
+  return getConfig(project).then((config) => {
+    return config.widget.name[0];
+  });
+};

--- a/lib/targets/ios/utils/parse-pbxproj.js
+++ b/lib/targets/ios/utils/parse-pbxproj.js
@@ -1,0 +1,62 @@
+const { Xcode } = require('pbxproj-dom/xcode');
+const fsUtils   = require('../../../utils/fs-utils');
+
+module.exports = function(path, appName) {
+  if (!fsUtils.existsSync(path)) {
+    throw `pbxproj file does not exist at ${path}`;
+  }
+
+  let pbxproj;
+  try {
+    pbxproj = Xcode.open(path);
+  } catch (err) {
+    throw `failed to parse pbxproj file at ${path}`;
+  }
+
+  let target;
+  let project = pbxproj.document.projects.find((p) => {
+    target = p.targets.find(t => t.name === appName);
+    return target;
+  });
+
+  if (!target) {
+    throw 'no build target found for app ${appName} in pbxproj file at '
+      + ` ${path}`;
+  }
+
+  let targetAttributes = project.ast.get('attributes')
+    .get('TargetAttributes')
+    .get(target.key);
+
+  let provisioningStyle = targetAttributes.get('ProvisioningStyle').text;
+  if (provisioningStyle) {
+    provisioningStyle = provisioningStyle.toLowerCase();
+  } else {
+    provisioningStyle = 'automatic';
+  }
+
+  let developmentTeam, buildConfigurations;
+  if (provisioningStyle === 'automatic') {
+    developmentTeam = targetAttributes.get('DevelopmentTeam').text;
+  } else {
+    let pbxBuildConfigs = target.buildConfigurationsList.buildConfigurations;
+    buildConfigurations = pbxBuildConfigs.reduce((hash, config) => {
+      let key = config.name.toLowerCase();
+      let buildSettings = config.ast.get('buildSettings');
+      let provisioningProfile = buildSettings.get('PROVISIONING_PROFILE').text;
+
+      hash[key] = {
+        name: key,
+        provisioningProfile
+      };
+
+      return hash;
+    }, {});
+  }
+
+  return {
+    provisioningStyle,
+    developmentTeam,
+    buildConfigurations
+  };
+};

--- a/lib/targets/ios/validators/signing-identity.js
+++ b/lib/targets/ios/validators/signing-identity.js
@@ -1,0 +1,58 @@
+const path         = require('path');
+const Task         = require('../../../tasks/-task');
+const getAppName   = require('../../cordova/utils/get-app-name');
+const getPath      = require('../../cordova/utils/get-path');
+const logger       = require('../../../utils/logger');
+const parsePbxproj = require('../utils/parse-pbxproj');
+
+module.exports = Task.extend({
+  buildConfigName: 'debug',
+  failed: undefined,
+  project: undefined,
+  logLevel: 'error',
+
+  run() {
+    this.failed = false;
+    return getAppName(this.project).then((appName) => {
+      let pbxprojPath = this._buildPbxprojPath(this.project, appName);
+      let config;
+      try {
+        config = parsePbxproj(pbxprojPath, appName);
+      } catch (err) {
+        return this._fail(err);
+      }
+
+      if (config.provisioningStyle === 'automatic' && !config.developmentTeam) {
+        return this._fail('xcode project is configured for automatic signing,'
+          + ' but no development team has been selected');
+      }
+
+      if (config.provisioningStyle === 'manual') {
+        let buildConfig = config.buildConfigurations[this.buildConfigName];
+        if (!buildConfig.provisioningProfile) {
+          return this._fail('xcode project is configured for manual signing,'
+            + ' but no provisioning profile has been selected');
+        }
+      }
+    });
+  },
+
+  _buildPbxprojPath(project, appName) {
+    return path.join(
+      getPath(project),
+      'platforms',
+      'ios',
+      `${appName}.xcodeproj`,
+      'project.pbxproj'
+    );
+  },
+
+  _fail(message) {
+    this.failed = true;
+    if (this.logLevel === 'warn') {
+      message += '; project may build, but archive will fail.';
+      return logger.warn(message);
+    }
+    throw `${message}.`;
+  }
+});

--- a/node-tests/unit/targets/cordova/utils/get-app-name-test.js
+++ b/node-tests/unit/targets/cordova/utils/get-app-name-test.js
@@ -1,0 +1,22 @@
+const td          = require('testdouble');
+const expect      = require('../../../../helpers/expect');
+const mockProject = require('../../../../fixtures/corber-mock/project');
+const getAppName  = require('../../../../../lib/targets/cordova/utils/get-app-name');
+const { Promise } = require('rsvp');
+
+describe('Get App Name Util', function() {
+  beforeEach(function() {
+    td.replace('../../../../../lib/targets/cordova/utils/get-config', () => {
+      return Promise.resolve({
+        widget: {
+          name: ['fooApp']
+        }
+      });
+    });
+  });
+
+  it('should return the correct app name', function() {
+    let project = mockProject.project;
+    expect(getAppName(project)).to.eventually.equal('fooApp');
+  });
+});

--- a/node-tests/unit/targets/ios/utils/parse-pbxproj-test.js
+++ b/node-tests/unit/targets/ios/utils/parse-pbxproj-test.js
@@ -1,0 +1,15 @@
+const td        = require('testdouble');
+const expect    = require('../../../../helpers/expect');
+const parsePbx  = require('../../../../../lib/targets/ios/utils/parse-pbxproj');
+const fsUtils   = require('../../../../../lib/utils/fs-utils');
+
+describe('Parse pbxproj Test', function() {
+  afterEach(function() {
+    td.reset();
+  });
+
+  it('throws if pbxproj file does not exist', function() {
+    td.replace(fsUtils, 'existsSync', () => false);
+    return expect(() => parsePbx('foo.pbxproj')).to.throw();
+  });
+});

--- a/node-tests/unit/targets/ios/validators/signing-identity-test.js
+++ b/node-tests/unit/targets/ios/validators/signing-identity-test.js
@@ -1,0 +1,109 @@
+const td          = require('testdouble');
+const expect      = require('../../../../helpers/expect');
+const mockProject = require('../../../../fixtures/corber-mock/project');
+
+describe('Signing Identity Test', function() {
+  let SigningIdentity;
+  let validator;
+  let pbxproj;
+
+  beforeEach(function() {
+    pbxproj = {};
+    td.replace('../../../../../lib/targets/ios/utils/parse-pbxproj', () => {
+      return pbxproj;
+    });
+
+    SigningIdentity =
+      require('../../../../../lib/targets/ios/validators/signing-identity');
+
+    validator = new SigningIdentity({
+      project: mockProject.project,
+      buildConfigName: 'debug'
+    });
+  });
+
+  afterEach(function () {
+    td.reset();
+  });
+
+  it('does not reject when log level is "warn"', function() {
+    pbxproj = {};
+    validator.logLevel = 'warn';
+    return expect(validator.run()).to.eventually.be.fulfilled;
+  });
+
+  context('when signing style is automatic', function() {
+    beforeEach(function() {
+      pbxproj.provisioningStyle = 'automatic';
+    });
+
+    context('when team is not set', function() {
+      it('rejects', function() {
+        return expect(validator.run()).to.eventually.be.rejected;
+      });
+
+      it('sets the "failed" property to true', function(done) {
+        validator.run().catch((err) => {
+          expect(validator.failed).to.be.true;
+          done();
+        });
+      });
+    });
+
+    context('when team is set', function() {
+      beforeEach(function() {
+        pbxproj.developmentTeam = 'isle-of-code';
+      });
+
+      it('resolves', function() {
+        return expect(validator.run()).to.eventually.be.fulfilled;
+      });
+
+      it('does not set the "failed" property to false', function(done) {
+        validator.run().then(() => {
+          expect(validator.failed).to.be.false;
+          done();
+        });
+      });
+    });
+  });
+
+  context('when signing style is manual', function() {
+    beforeEach(function() {
+      pbxproj.provisioningStyle = 'manual';
+      pbxproj.buildConfigurations = {
+        debug: {}
+      }
+    });
+
+    context('when provisioning profile is not set', function() {
+      it('rejects', function() {
+        return expect(validator.run()).to.eventually.be.rejected;
+      });
+
+      it('set the "failed" property to true', function(done) {
+        validator.run().catch((err) => {
+          expect(validator.failed).to.be.true;
+          done();
+        });
+      });
+    });
+
+    context('when provisioning profile is set', function() {
+      beforeEach(function() {
+        pbxproj.buildConfigurations['debug'].provisioningProfile = 'profile';
+      });
+
+      it('resolves', function() {
+        return expect(validator.run()).to.eventually.be.fulfilled;
+      });
+
+      it('sets the "failed" property to false', function(done) {
+        validator.run().then(() => {
+          expect(validator.failed).to.be.false;
+          done();
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "htmlparser2": "^3.9.2",
     "leek": "0.0.24",
     "lodash": "^4.13.1",
+    "pbxproj-dom": "^1.0.11",
     "portfinder": "^1.0.5",
     "rimraf": "^2.5.4",
     "rsvp": "^4.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,6 +4761,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pbxproj-dom@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pbxproj-dom/-/pbxproj-dom-1.0.11.tgz#3136c6d6da61c24396f01cafaf9c4124668f4c05"
+
 pegjs@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"


### PR DESCRIPTION
- Parses xcode pbxproj file to determine presence of signing identity.
- Shows a message before and after build if missing (archive will fail first, showing a nasty error #65).
- Eliminates double error reporting from re-raised exception in build catch block.