### PR TITLE
Fix/Improve framework detection

### DIFF
--- a/lib/tasks/create-project.js
+++ b/lib/tasks/create-project.js
@@ -23,20 +23,34 @@ module.exports = Task.extend({
   initDirs(project) {
     let emberCdvPath = path.join(project.root, 'corber');
     let projectConfig = path.resolve(emberCdvPath, 'config/framework.js');
-    let framework = frameworkType.get(project.root);
+    let detectedFrameworks = frameworkType.detectAll(project.root);
 
-    if (framework === 'custom') {
-      this.warnCustomFramework();
+    let frameworkPromise;
+    if (detectedFrameworks.length === 1) {
+      frameworkPromise = Promise.resolve({ framework: detectedFrameworks[0] });
+    } else {
+      frameworkPromise = this.ui.prompt({
+        type: 'list',
+        name: 'framework',
+        message: 'Select your framework type:',
+        choices: detectedFrameworks
+      });
     }
 
-    let configPath = path.join(
-      __dirname,
-      '../templates/frameworks',
-      `${framework}.js`
-    );
+    let configPath
+    return frameworkPromise.then(({ framework }) => {
+      if (framework === 'custom') {
+        this.warnCustomFramework();
+      }
 
-    return fsUtils.mkdir(emberCdvPath)
-      .then(() => fsUtils.mkdir(path.join(emberCdvPath, 'config')))
+      configPath = path.join(
+        __dirname,
+        '../templates/frameworks',
+        `${framework}.js`
+      );
+
+      return fsUtils.mkdir(emberCdvPath);
+    }).then(() => fsUtils.mkdir(path.join(emberCdvPath, 'config')))
       .then(() => fsUtils.copy(configPath, projectConfig));
   },
 

--- a/lib/utils/framework-type.js
+++ b/lib/utils/framework-type.js
@@ -1,24 +1,36 @@
+const some              = require('lodash').some;
 const get              = require('lodash').get;
 const path             = require('path');
 const getPackage       = require('./get-package');
 
+const frameworkPackages = {
+  glimmer: ['@glimmer/application'],
+  ember: ['ember-resolver', 'ember-source'],
+  vue: ['vue'],
+  react: ['react']
+};
+
 module.exports = {
-  get(root) {
+  detectAll(root) {
     let packagePath = path.join(root, 'package.json');
     let packageJSON = getPackage(packagePath);
     let devDeps = packageJSON.devDependencies;
     let deps = packageJSON.dependencies;
 
-    if (get(devDeps, '@glimmer/application')) {
-      return 'glimmer';
-    } else if (get(devDeps, 'ember-resolver') || get(devDeps, 'ember-source')) {
-      return 'ember';
-    } else if (get(deps, 'vue')) {
-      return 'vue';
-    } else if (get(deps, 'react')) {
-      return 'react';
-    } else {
-      return 'custom';
+    let frameworks = Object.keys(frameworkPackages).filter((framework) => {
+      return some(frameworkPackages[framework], (pkg) => {
+        return get(deps, pkg) || get(devDeps, pkg);
+      });
+    });
+
+    if (frameworks.length === 0) {
+      return ['custom'];
     }
+
+    return frameworks;
+  },
+
+  get(root) {
+    return this.detectAll()[0];
   }
 };

--- a/node-tests/unit/tasks/create-project-test.js
+++ b/node-tests/unit/tasks/create-project-test.js
@@ -107,8 +107,8 @@ describe('Create Project', function() {
   });
 
   it('warns if framework type is custom', function() {
-    td.replace(frameworkType, 'get', function() {
-      return 'custom';
+    td.replace(frameworkType, 'detectAll', function() {
+      return ['custom'];
     });
 
     initTask(false);
@@ -127,9 +127,11 @@ describe('Create Project', function() {
       'corber'
     );
 
+    let emberCdvConfigPath = path.resolve(emberCdvPath, 'config');
+
     beforeEach(function() {
-      td.replace(frameworkType, 'get', function() {
-        return 'ember';
+      td.replace(frameworkType, 'detectAll', function() {
+        return ['ember'];
       });
     });
 
@@ -138,17 +140,18 @@ describe('Create Project', function() {
     });
 
     it('inits corber && config directories', function() {
-      let mkDirPath = '';
+      let mkDirPaths = [];
 
       td.replace(fsUtils, 'mkdir', function(corberPath) {
-        mkDirPath = corberPath;
+        mkDirPaths.push(corberPath);
         return Promise.resolve();
       });
 
       initTask(false);
-      createTask.run();
-
-      expect(mkDirPath).to.equal(emberCdvPath);
+      return createTask.run().then(function() {
+        expect(mkDirPaths).to.include(emberCdvPath);
+        expect(mkDirPaths).to.include(emberCdvConfigPath);
+      });
     });
 
     it('attempts to copy the frameworks config', function() {

--- a/node-tests/unit/utils/framework-type-test.js
+++ b/node-tests/unit/utils/framework-type-test.js
@@ -19,10 +19,26 @@ describe('Framework', function() {
     });
 
     let frameworkType  = require('../../../lib/utils/framework-type');
-    expect(frameworkType.get(root)).to.equal('glimmer');
+    let frameworks = frameworkType.detectAll(root);
+    expect(frameworks.length).to.eq(1);
+    expect(frameworks).to.include('glimmer');
   });
 
-  it('detects ember', function() {
+  it('detects ember as a dependency', function () {
+    td.replace('../../../lib/utils/get-package', function () {
+      return {
+        name: 'my-app',
+        dependencies: {
+          'ember-source': '^0.5.1',
+        }
+      };
+    });
+
+    let frameworkType = require('../../../lib/utils/framework-type');
+    expect(frameworkType.detectAll(root)).to.include('ember');
+  });
+
+  it('detects ember as a dev dependency', function() {
     td.replace('../../../lib/utils/get-package', function() {
       return {
         name: 'my-app',
@@ -33,7 +49,7 @@ describe('Framework', function() {
     });
 
     let frameworkType  = require('../../../lib/utils/framework-type');
-    expect(frameworkType.get(root)).to.equal('ember');
+    expect(frameworkType.detectAll(root)).to.include('ember');
   });
 
   it('detect vue', function() {
@@ -47,7 +63,7 @@ describe('Framework', function() {
     });
 
     let frameworkType  = require('../../../lib/utils/framework-type');
-    expect(frameworkType.get(root)).to.equal('vue');
+    expect(frameworkType.detectAll(root)).to.include('vue');
   });
 
   it('detect react', function() {
@@ -61,7 +77,7 @@ describe('Framework', function() {
     });
 
     let frameworkType  = require('../../../lib/utils/framework-type');
-    expect(frameworkType.get(root)).to.equal('react');
+    expect(frameworkType.detectAll(root)).to.include('react');
   });
 
   it('returns custom if no type is detected', function() {
@@ -73,6 +89,27 @@ describe('Framework', function() {
     });
 
     let frameworkType  = require('../../../lib/utils/framework-type');
-    expect(frameworkType.get(root)).to.equal('custom');
+    expect(frameworkType.detectAll(root)).to.include('custom');
+  });
+
+  it('detects more than one framework type', function() {
+    td.replace('../../../lib/utils/get-package', function () {
+      return {
+        name: 'my-app',
+        dependencies: {
+          'react': '0.0.0',
+          'vue': '0.0.0'
+        },
+        devDependencies: {
+          '@glimmer/application': '^0.5.1',
+          'ember-source': '^0.5.1',
+        }
+      };
+    });
+    let frameworkType = require('../../../lib/utils/framework-type');
+    expect(frameworkType.detectAll(root)).to.include('glimmer');
+    expect(frameworkType.detectAll(root)).to.include('ember');
+    expect(frameworkType.detectAll(root)).to.include('vue');
+    expect(frameworkType.detectAll(root)).to.include('react');
   });
 });


### PR DESCRIPTION
- Searches `package.json` for framework packages in both `dependencies`
and `devDependencies`.
- Detects packages from multiple frameworks.
- Provides a prompt to select framework if more than one detected.

Resolves: Ember.js - Your framework type (Ember/Vue/Glimmer was not identified. #478