### PR TITLE
Fix/Tell CordovaLib to fetch missing plugin during webview setup

### DIFF
--- a/lib/targets/cordova/tasks/setup-webview.js
+++ b/lib/targets/cordova/tasks/setup-webview.js
@@ -56,7 +56,10 @@ module.exports = Task.extend({
     }
 
     if (viewName !== undefined) {
-      return upgradeWebView.run('add', viewName, { save: true });
+      return upgradeWebView.run('add', viewName, {
+        save: true,
+        fetch: true
+      });
     } else {
       return Promise.resolve();
     }


### PR DESCRIPTION
Fixes the error `Corber: Cannot read property 'fail' of undefined` caused by initing, removing, and re-adding an iOS platform. A bug in CordovaLib calls `fail` on an undefined promise unless the plugin already exists or an explicit `--fetch` argument is passed.