### PR TITLE
Feat/Show global, project, node versions

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -1,15 +1,25 @@
 const Command          = require('./-command');
 const logger           = require('../utils/logger');
-const packageJSON      = require('../../package.json');
+const getVersions      = require('../utils/get-versions');
+const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
   name: 'version',
-  aliases: ['-v', '--version'],
+  aliases: ['v', '-v', '--version'],
   description: 'Prints the current version of Corber',
-  works: 'insideProject',
 
   run(options) {
     this._super.apply(this, arguments);
-    logger.info(`v${packageJSON.version}`);
+
+    let versions = getVersions(this.project.root);
+    logger.info(`corber (global): ${versions.corber.global}`);
+
+    if (versions.corber.project) {
+      logger.info(`corber (project): ${versions.corber.project}`);
+    }
+
+    logger.info(`node: ${versions.node}`);
+
+    return Promise.resolve();
   }
 });

--- a/lib/utils/get-versions.js
+++ b/lib/utils/get-versions.js
@@ -1,0 +1,37 @@
+const path       = require('path');
+const getPackage = require('./get-package');
+const existsSync = require('./fs-utils').existsSync;
+
+module.exports = function getVersions(root) {
+  let versions = {
+    corber: {},
+    node: process.versions.node
+  }
+
+  let globalPackagePath = path.join('..', '..', 'package.json');
+  let globalPackage = getPackage(globalPackagePath);
+
+  versions.corber.global = globalPackage.version;
+
+  if (root) {
+    let projectPackagePath = path.join(root, 'package.json');
+
+    if (existsSync(projectPackagePath)) {
+      let projectPackage = getPackage(projectPackagePath);
+
+      let dependenciesVersion;
+      if (projectPackage.dependencies) {
+        dependenciesVersion = projectPackage.dependencies.corber;
+      }
+
+      let devDependenciesVersion;
+      if (projectPackage.devDependencies) {
+        devDependenciesVersion = projectPackage.devDependencies.corber;
+      }
+
+      versions.corber.project = dependenciesVersion || devDependenciesVersion;
+    }
+  }
+
+  return versions;
+};

--- a/node-tests/unit/commands/version-test.js
+++ b/node-tests/unit/commands/version-test.js
@@ -1,0 +1,57 @@
+const td          = require('testdouble');
+const mockProject = require('../../fixtures/corber-mock/project');
+
+const logger      = require('../../../lib/utils/logger');
+const contains    = td.matchers.contains;
+
+let versions, infoDouble, versionCmd;
+
+describe('Version Command', () => {
+  beforeEach(() => {
+    versions = {
+      corber: {
+        global: '1.0.0',
+        project: '2.0.0'
+      },
+      node: '8.9.4'
+    };
+
+    td.replace('../../../lib/utils/get-versions', (root) => {
+      return versions;
+    });
+
+    infoDouble = td.replace(logger, 'info');
+
+    let VersionCmd = require('../../../lib/commands/version');
+
+    versionCmd = new VersionCmd({
+      project: mockProject.project
+    });
+  });
+
+  afterEach(() => {
+    td.reset();
+  });
+
+  describe('run', () => {
+    it('shows corber and node versions', () => {
+      return versionCmd.run().then(() => {
+        td.verify(infoDouble('corber (global): 1.0.0'));
+        td.verify(infoDouble('corber (project): 2.0.0'));
+        td.verify(infoDouble('node: 8.9.4'));
+      })
+    });
+
+    context('when project version unavailable', () => {
+      beforeEach(() => {
+        delete versions.corber.project;
+      });
+
+      it('does not show project version', () => {
+        return versionCmd.run().then(() => {
+          td.verify(infoDouble(contains('corber (project)')), { times: 0 });
+        })
+      });
+    })
+  });
+});

--- a/node-tests/unit/utils/get-versions-test.js
+++ b/node-tests/unit/utils/get-versions-test.js
@@ -1,0 +1,75 @@
+const td                 = require('testdouble');
+const expect             = require('../../helpers/expect');
+const path               = require('path');
+const fsUtils            = require('../../../lib/utils/fs-utils');
+const mockProject        = require('../../fixtures/corber-mock/project');
+const root               = mockProject.project.root;
+const globalPackagePath  = path.join('..', '..', 'package.json');
+const projectPackagePath = path.join(root, 'package.json');
+
+let packages, fileExists, getVersions;
+
+describe('getVersions', () => {
+  beforeEach(() => {
+    packages = {};
+    packages[globalPackagePath] = { version: '1.0.0' };
+    packages[projectPackagePath] = {
+      devDependencies: {
+        corber: '1.2.3'
+      }
+    };
+
+    td.replace('../../../lib/utils/get-package', (packagePath) => {
+      return packages[packagePath];
+    });
+
+    fileExists = {};
+    fileExists[projectPackagePath] = true;
+
+    td.replace(fsUtils, 'existsSync', (filePath) => {
+      return fileExists[filePath];
+    });
+
+    getVersions = require('../../../lib/utils/get-versions');
+  });
+
+  afterEach(() => {
+    td.reset();
+  });
+
+  it('reads the global corber version', () => {
+    let versions = getVersions(root);
+    expect(versions.corber.global).to.equal('1.0.0');
+  });
+
+  it('reads the project corber version', () => {
+    let versions = getVersions(root);
+    expect(versions.corber.project).to.equal('1.2.3');
+  });
+
+  it('reads the node version', () => {
+    let versions = getVersions(root);
+    expect(versions.node).to.equal(process.versions.node);
+  });
+
+  context('when corber is added as a full dependency', () => {
+    beforeEach(() => {
+      delete packages[projectPackagePath].devDependencies;
+
+      packages[projectPackagePath].dependencies = {
+        corber: '1.2.3'
+      };
+    });
+  });
+
+  context('when project package.json does not exist', () => {
+    beforeEach(() => {
+      fileExists[projectPackagePath] = false;
+    });
+
+    it('does not contain a project version', () => {
+      let versions = getVersions(root);
+      expect(versions.corber.project).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
Extends the work of @ddoria921 to also display project corber version and node version (compare with `ember version`). Adds tests.