### PR TITLE
feat(command): check for corber project when running commands

### DIFF
--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -3,9 +3,15 @@ const Leek         = require('leek');
 const ConfigStore  = require('configstore');
 const uuid         = require('uuid');
 const _get         = require('lodash').get;
+const chalk        = require('chalk');
 const logger       = require('../utils/logger');
+const getVersions  = require('../utils/get-versions');
 
 module.exports = Command.extend({
+  // use `scope` instead of `works` in sub-objects
+  works: 'everywhere',
+  scope: 'insideProject',
+
   //h/t ember-cli
   getUUID() {
     let configStore = new ConfigStore('corber');
@@ -23,6 +29,9 @@ module.exports = Command.extend({
 
     process.env.CORBER = true;
 
+    let versions = getVersions(this.project.root);
+    this.isWithinProject = (versions.corber.project !== undefined);
+
     let disabled = _get(app, 'settings.disableEcAnalytics', false);
     let version = _get(app, 'project.addonPackages.corber.pkg.version');
     let id = this.getUUID();
@@ -34,6 +43,20 @@ module.exports = Command.extend({
       trackingCode: 'UA-50368464-2',
       version: version
     });
+  },
+
+  validateAndRun() {
+    if (this.scope === 'outsideProject' && this.isWithinProject) {
+      throw `You cannot use the ${chalk.green(this.name)}` +
+      ' command inside a corber project.';
+    }
+
+    if (this.scope === 'insideProject' && !this.isWithinProject) {
+      throw `You cannot use the ${chalk.green(this.name)} command outside` +
+      ' of a corber project. Have you run corber init?';
+    }
+
+    this._super.apply(this, arguments);
   },
 
   run(options) {

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -12,7 +12,6 @@ module.exports = Command.extend({
   name: 'build',
   aliases: ['b'],
   description: 'Build the ember application for cordova',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [

--- a/lib/commands/cordova.js
+++ b/lib/commands/cordova.js
@@ -8,9 +8,10 @@ module.exports = Command.extend({
   name: 'cordova',
   aliases: ['cdv'],
   description: 'Deprecated',
-  works: 'insideProject',
 
   run: function(options, rawArgs) {
+    this._super.apply(this, arguments);
+
     logger.warn(
       'DEPRECATION WARNING (corber): ember cdv proxy syntax has been deprecated in favor of ember cdv:proxy\n' +
       'The prior proxy command was "ember cdv $COMMAND" \n' +

--- a/lib/commands/devices.js
+++ b/lib/commands/devices.js
@@ -6,7 +6,6 @@ module.exports = Command.extend({
   name: 'devices',
   aliases: ['d'],
   description: 'List Devices',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,6 +10,7 @@ const Promise         = RSVP.Promise;
 module.exports = Command.extend({
   name: 'init',
   aliases: ['i'],
+  scope: 'outsideProject',
 
   availableOptions: [
     { name: 'name',                 type: String },
@@ -64,6 +65,8 @@ module.exports = Command.extend({
   },
 
   run(opts) {
+    this._super.apply(this, arguments);
+
     let create = new CreateProject({
       project: this.project,
       ui: this.ui,

--- a/lib/commands/lint-index.js
+++ b/lib/commands/lint-index.js
@@ -6,7 +6,6 @@ const path             = require('path');
 module.exports = Command.extend({
   name: 'lint-index',
   description: 'Lints index.html for attributes with paths relative to root.',
-  works: 'insideProject',
 
   availableOptions: [{
     name: 'source',

--- a/lib/commands/make-icons.js
+++ b/lib/commands/make-icons.js
@@ -11,7 +11,6 @@ module.exports = Command.extend({
   name: 'make-icons',
   aliases: [ 'icons' ],
   description: 'Generates cordova icon files and updates config',
-  works: 'insideProject',
 
   availableOptions: [{
     name: 'source',

--- a/lib/commands/make-splashes.js
+++ b/lib/commands/make-splashes.js
@@ -11,7 +11,6 @@ module.exports = Command.extend({
   name: 'make-splashes',
   aliases: [ 'splashes' ],
   description: 'Generates cordova splash files and updates config',
-  works: 'insideProject',
 
   availableOptions: [{
     name: 'source',

--- a/lib/commands/open.js
+++ b/lib/commands/open.js
@@ -8,7 +8,6 @@ module.exports = Command.extend({
   aliases: [ 'o' ],
   description: 'Open the native platform project with the default or ' +
     'specified application',
-  works: 'insideProject',
 
   availableOptions: [
     { name: 'platform', type: String, default: 'ios' },

--- a/lib/commands/platform.js
+++ b/lib/commands/platform.js
@@ -8,7 +8,6 @@ module.exports = Command.extend({
   name: 'platform',
   aliases: [ 'pl' ],
   description: 'Add/remove platforms',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [

--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -11,7 +11,6 @@ module.exports = Command.extend({
   name: 'plugin',
   aliases: [ 'p' ],
   description: 'Add/remove plugins',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [
@@ -27,6 +26,8 @@ module.exports = Command.extend({
   /* eslint-enable max-len */
 
   run(options, rawArgs) {
+    this._super.apply(this, arguments);
+
     let cordovaArgSanitizer = new SanitizeArgs({
       rawArgs: rawArgs,
       letOpts: options.variable,

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -7,7 +7,6 @@ const Promise          = require('rsvp').Promise;
 module.exports = Command.extend({
   name: 'prepare',
   description: 'Runs cordova prepare and ember cdv link',
-  works: 'insideProject',
 
   availableOptions: [
     { name: 'verbose', type: Boolean, default: false, aliases: ['v'] }

--- a/lib/commands/proxy.js
+++ b/lib/commands/proxy.js
@@ -9,7 +9,6 @@ let ValidateCordova = require('../targets/cordova/validators/is-installed');
 module.exports = Command.extend({
   name: 'proxy',
   description: 'Passes commands to Cordova CLI',
-  works: 'insideProject',
 
   supportedCommands: [
     'build',

--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -13,7 +13,6 @@ module.exports = Command.extend({
   name: 'serve',
   aliases: [ 's' ],
   description: 'Builds app, then runs liveReload server',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -21,7 +21,6 @@ module.exports = Command.extend({
   name: 'start',
   aliases: [ 'start' ],
   description: 'Run app on device/emulator /w livereload',
-  works: 'insideProject',
 
   /* eslint-disable max-len */
   availableOptions: [

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -7,6 +7,7 @@ module.exports = Command.extend({
   name: 'version',
   aliases: ['v', '-v', '--version'],
   description: 'Prints the current version of Corber',
+  scope: 'everywhere',
 
   run(options) {
     this._super.apply(this, arguments);


### PR DESCRIPTION
Without overriding `validateAndRun` altogether, it's not possible to override the error message when using the `works` property on `ember-cli` command objects. This PR replaces defeats the `works` property and substitutes a `scope` property which achieves the same effect.