### PR TITLE
Fix/Init command scope & errors

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -2,7 +2,10 @@ const Command         = require('./-command');
 const CreateProject   = require('../tasks/create-project');
 const PlatformTask    = require('../targets/cordova/tasks/platform');
 const logger          = require('../utils/logger');
+const fsUtils         = require('../utils/fs-utils');
 const getOS           = require('../utils/get-os');
+const getVersions     = require('../utils/get-versions');
+const chalk           = require('chalk');
 const RSVP            = require('rsvp');
 const _pick           = require('lodash').pick;
 const Promise         = RSVP.Promise;
@@ -10,7 +13,9 @@ const Promise         = RSVP.Promise;
 module.exports = Command.extend({
   name: 'init',
   aliases: ['i'],
-  scope: 'outsideProject',
+
+  // init has special scope handling in `validateAndRun`
+  scope: 'everywhere',
 
   availableOptions: [
     { name: 'name',                 type: String },
@@ -62,6 +67,21 @@ module.exports = Command.extend({
     });
 
     return RSVP.allSettled(installs);
+  },
+
+  validateAndRun() {
+    let versions = getVersions(this.project.root);
+    if (versions.corber.project !== undefined) {
+      throw `You cannot use ${chalk.green('corber init')} if corber is ` +
+        'already present in your project\'s package.json';
+    }
+
+    if (fsUtils.existsSync('./corber')) {
+      throw `You cannot use ${chalk.green('corber init')} if your project ` +
+        'already contains a corber folder';
+    }
+
+    return this._super.apply(this, arguments);
   },
 
   run(opts) {

--- a/node-tests/unit/commands/init-test.js
+++ b/node-tests/unit/commands/init-test.js
@@ -103,6 +103,34 @@ describe('Init Command', function() {
     });
   });
 
+  describe('validateAndRun', function() {
+    context('when corber is already initialized', function() {
+      it('throws an exception', function() {
+        td.replace('../../../lib/utils/get-versions', () => {
+          return {
+            corber: {
+              project: '1.0.0'
+            }
+          };
+        });
+
+        let init = setupCmd();
+        expect(() => init.validateAndRun()).to.throw();
+      });
+    });
+
+    context('when corber folder already exists in project', function() {
+      it('throws an exception', function () {
+        td.replace('../../../lib/utils/fs-utils', 'existsSync', (path) => {
+          return path !== './corber';
+        });
+
+        let init = setupCmd();
+        expect(() => init.validateAndRun()).to.throw();
+      });
+    });
+  });
+
   describe('getPlatforms', function() {
     it('splits a single string', function() {
       let init = setupCmd();


### PR DESCRIPTION
When running `corber init`:
- Show an explicit error if `corber` is already present in `package.json`.
- Show an explicit error if a `corber` folder is already present in project.
