### PR TITLE
Feat/Ember Targets

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -61,6 +61,9 @@ module.exports = Command.extend({
     this.project.targetIsCordova = true;
     this.project.CORBER_PLATFORM = options.platform;
 
+    // allows platform-specific tuning in framework build pipeline
+    process.env.CORBER_PLATFORM = options.platform;
+
     let hook = new Hook({
       project: this.project
     });

--- a/lib/frameworks/ember/framework.js
+++ b/lib/frameworks/ember/framework.js
@@ -10,6 +10,7 @@ const _merge           = require('lodash').merge;
 
 const UpdateWatchmanIgnore     = require('./tasks/update-watchman-config');
 const ValidateLocationType     = require('./validators/location-type');
+const ValidateBrowserTargets   = require('./validators/browser-targets');
 const ValidateRootUrl          = require('../../validators/root-url');
 /* eslint-enable max-len */
 
@@ -41,6 +42,13 @@ module.exports = Framework.extend({
       new ValidateLocationType({
         config: projectConfig,
         force: options.force
+      }).run()
+    );
+
+    validations.push(
+      new ValidateBrowserTargets({
+        config: projectConfig,
+        root: this.project.root
       }).run()
     );
 

--- a/lib/frameworks/ember/utils/get-cli-version.js
+++ b/lib/frameworks/ember/utils/get-cli-version.js
@@ -1,0 +1,30 @@
+const fsUtils    = require('../../../utils/fs-utils');
+const getPackage = require('../../../utils/get-package');
+const path       = require('path');
+const semver     = require('semver');
+
+module.exports = function(root) {
+  let emberCLIPackagePath = path.join(
+    root,
+    'node_modules',
+    'ember-cli',
+    'package.json'
+  );
+
+  if (fsUtils.existsSync(emberCLIPackagePath)) {
+    let packageJSON = getPackage(emberCLIPackagePath);
+    return packageJSON.version;
+  }
+
+  let packagePath = path.join(root, 'package.json');
+  let packageJSON = getPackage(packagePath);
+  let { dependencies, devDependencies } = packageJSON;
+
+  if (dependencies && dependencies['ember-cli']) {
+    return semver.coerce(dependencies['ember-cli']).version;
+  }
+
+  if (devDependencies && devDependencies['ember-cli']) {
+    return semver.coerce(devDependencies['ember-cli']).version;
+  }
+};

--- a/lib/frameworks/ember/validators/browser-targets.js
+++ b/lib/frameworks/ember/validators/browser-targets.js
@@ -1,0 +1,49 @@
+/* eslint-disable max-len */
+const Task            = require('../../../tasks/-task');
+const rsvp            = require('rsvp');
+const semver          = require('semver');
+const path            = require('path');
+const getCLIVersion   = require('../../../frameworks/ember/utils/get-cli-version');
+const logger          = require('../../../utils/logger');
+const fsUtils         = require('../../../utils/fs-utils');
+const Promise         = rsvp.Promise;
+
+const WEBSITE = 'http://corber.io/pages/frameworks/ember#configuring-browser-targets';
+
+const CORBER_PLATFORM_REGEX = /process\.env\.CORBER_PLATFORM/;
+const EMBER_CLI_MIN_VERSION = '2.13.0';
+/* eslint-enable max-len */
+
+module.exports = Task.extend({
+  root: undefined,
+
+  run() {
+    let targetsPath = path.join(this.root, 'config', 'targets.js');
+    let targetsJs = path.join('config', 'targets.js');
+    let cliVersion = getCLIVersion(this.root);
+
+    // targets.js doesn't exist prior to ember-cli 2.13
+    if (!cliVersion || semver.lt(cliVersion, EMBER_CLI_MIN_VERSION)) {
+      return Promise.resolve();
+    }
+
+    if (!fsUtils.existsSync(targetsPath)) {
+      logger.warn(
+        `${targetsJs} was not found. When building with ember-cli 2.13 or `
+        + 'later, your project can be configured to generate platform-'
+        + `optimized corber builds. See ${WEBSITE} for details.`
+      );
+
+      return Promise.resolve();
+    }
+
+    return fsUtils.read(targetsPath, { encoding: 'utf8' }).then((contents) => {
+      if (!contents.match(CORBER_PLATFORM_REGEX)) {
+        logger.warn(
+          `${targetsJs} has not been configured for platform-optimized ` +
+          `corber builds. See ${WEBSITE} for details.`
+        );
+      }
+    });
+  }
+});

--- a/node-tests/unit/frameworks/ember/framework-test.js
+++ b/node-tests/unit/frameworks/ember/framework-test.js
@@ -92,13 +92,19 @@ describe('Ember Framework', function() {
 
   context('buildValidators', function() {
     it('inits validations', function() {
+      let ValidateBrowserTargets = td.replace('../../../../lib/frameworks/ember/validators/browser-targets');
       let ValidateLocation = td.replace('../../../../lib/frameworks/ember/validators/location-type');
       let ValidateRoot = td.replace('../../../../lib/validators/root-url');
+
       let Ember = require('../../../../lib/frameworks/ember/framework');
 
       let framework = new Ember({project: mockProject.project, isGlimmer: false});
       let validators = framework._buildValidators({});
 
+      td.verify(new ValidateBrowserTargets({
+        config: mockProject.project.config(),
+        root: mockProject.project.root
+      }));
 
       td.verify(new ValidateLocation({
         config: mockProject.project.config(),
@@ -112,7 +118,7 @@ describe('Ember Framework', function() {
         force: undefined
       }));
 
-      expect(validators.length).to.equal(2);
+      expect(validators.length).to.equal(3);
     });
 
     it('passes the force flag to ValidateRootURL', function() {

--- a/node-tests/unit/frameworks/ember/utils/get-cli-version-test.js
+++ b/node-tests/unit/frameworks/ember/utils/get-cli-version-test.js
@@ -1,0 +1,60 @@
+const td              = require('testdouble');
+const expect          = require('../../../../helpers/expect');
+const mockProject     = require('../../../../fixtures/corber-mock/project');
+const path            = require('path');
+const root            = mockProject.project.root;
+
+let cliPackagePath    = path.join(root, 'node_modules', 'ember-cli', 'package.json');
+let packagePath       = path.join(root, 'package.json');
+
+describe('Get Ember CLI version test', () => {
+  let fsUtils, getPackage;
+  let getCLIVersion;
+
+  beforeEach(() => {
+    fsUtils = td.replace('../../../../../lib/utils/fs-utils');
+    getPackage = td.replace('../../../../../lib/utils/get-package');
+
+    getCLIVersion = require('../../../../../lib/frameworks/ember/utils/get-cli-version');
+
+    td.when(fsUtils.existsSync(cliPackagePath)).thenReturn(true);
+    td.when(getPackage(cliPackagePath)).thenReturn({ version: '2.13.2' });
+    td.when(getPackage(packagePath)).thenReturn({
+      devDependencies: {
+        'ember-cli': '~2.13.0'
+      }
+    });
+  });
+
+  afterEach(() => {
+    td.reset();
+  });
+
+  it('returns the node_modules/ember-cli/package.json version', () => {
+    expect(getCLIVersion(root)).to.equal('2.13.2');
+  });
+
+  context('when node_modules/ember-cli/package.json does not exist', () => {
+    beforeEach(() => {
+      td.when(fsUtils.existsSync(cliPackagePath)).thenReturn(false);
+    });
+
+    it('coerces version from package.json devDependencies', () => {
+      expect(getCLIVersion(root)).to.equal('2.13.0');
+    });
+
+    context('when ember-cli is in package.json dependencies', () => {
+      beforeEach(() => {
+        td.when(getPackage(packagePath)).thenReturn({
+          dependencies: {
+            'ember-cli': '~3.10.0'
+          }
+        });
+      })
+
+      it('coerces version from package.json devDependencies', () => {
+        expect(getCLIVersion(root)).to.equal('3.10.0');
+      });
+    });
+  });
+});

--- a/node-tests/unit/frameworks/ember/validators/browser-targets-test.js
+++ b/node-tests/unit/frameworks/ember/validators/browser-targets-test.js
@@ -1,0 +1,107 @@
+const td              = require('testdouble');
+const expect          = require('../../../../helpers/expect');
+const mockProject     = require('../../../../fixtures/corber-mock/project');
+const path            = require('path');
+const contains        = td.matchers.contains;
+const anything        = td.matchers.anything;
+const root            = mockProject.project.root;
+
+let targetsPath       = path.join(root, 'config', 'targets.js');
+
+describe('Validate Browser Targets', () => {
+  let fsUtils, logger, getCLIVersion;
+  let validation;
+
+  beforeEach(() => {
+    getCLIVersion = td.replace('../../../../../lib/frameworks/ember/utils/get-cli-version');
+    fsUtils = td.replace('../../../../../lib/utils/fs-utils');
+    logger = td.replace('../../../../../lib/utils/logger');
+
+    let BrowserTargetsValidation = require('../../../../../lib/frameworks/ember/validators/browser-targets');
+    validation = new BrowserTargetsValidation({ root });
+
+    td.when(getCLIVersion(root)).thenReturn('2.13.0');
+    td.when(fsUtils.existsSync(targetsPath)).thenReturn(true);
+    td.when(fsUtils.read(targetsPath), { ignoreExtraArgs: true })
+      .thenResolve('if (process.env.CORBER_PLATFORM) { /* optimize */ }');
+  });
+
+  afterEach(() => {
+    td.reset();
+  });
+
+  it('resolves', () => {
+    return expect(validation.run()).to.eventually.be.fulfilled;
+  });
+
+  it('does not log a warning', () => {
+    return validation.run().then(() => {
+      td.verify(logger.warn(anything()), { times: 0 });
+    });
+  });
+
+  context('when targets.js does not exist', () => {
+    beforeEach(() => {
+      td.when(fsUtils.existsSync(targetsPath)).thenReturn(false);
+    });
+
+    it('resolves', () => {
+      return expect(validation.run()).to.eventually.be.fulfilled;
+    });
+
+    it('warns that targets.js was not found', () => {
+      return validation.run().then(() => {
+        td.verify(logger.warn(contains('targets.js was not found')));
+      });
+    });
+
+    context('when ember-cli is < 2.13', () => {
+      beforeEach(() => {
+        td.when(getCLIVersion(root)).thenReturn('2.12.0');
+      });
+
+      it('resolves', () => {
+        return expect(validation.run()).to.eventually.be.fulfilled;
+      });
+
+      it('does not log a warning', () => {
+        return validation.run().then(() => {
+          td.verify(logger.warn(anything()), { times: 0 });
+        });
+      });
+    });
+  });
+
+  context('when targets.js does not reference env variable', () => {
+    beforeEach(() => {
+      td.when(fsUtils.read(targetsPath), { ignoreExtraArgs: true })
+        .thenResolve('/* not optimized */');
+    });
+
+    it('resolves', () => {
+      return expect(validation.run()).to.eventually.be.fulfilled;
+    });
+
+    it('warns that targets.js has not been configured', () => {
+      return validation.run().then(() => {
+        td.verify(logger.warn(contains('targets.js has not been configured')));
+      });
+    });
+
+    context('when ember-cli is < 2.13', () => {
+      beforeEach(() => {
+        td.when(getCLIVersion(root)).thenReturn('2.12.0');
+      });
+
+      it('resolves', () => {
+        return expect(validation.run()).to.eventually.be.fulfilled;
+      });
+
+      it('does not log a warning', () => {
+        return validation.run().then(() => {
+          td.verify(logger.warn(anything()), { times: 0 });
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "portfinder": "^1.0.5",
     "rimraf": "^2.5.4",
     "rsvp": "^4.6.1",
+    "semver": "^5.5.0",
     "sort-package-json": "^1.7.0",
     "splicon": "^0.0.14",
     "svg2png": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,6 +5346,10 @@ sax@>=0.6.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 send@0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"


### PR DESCRIPTION
`ember-cli` 2.13 and later projects have a `config/targets.js` file that optimizes transpilation for chosen browsers. For corber builds, it is advantageous to target only mobile safari or android, depending on the build platform. This PR does not modify the file directly, but detects when it has not referenced the env variable and shows a warning with a link to the website for more information.

Addresses #490.