### PR TITLE
Feat/Upgrade version command

### DIFF
--- a/lib/commands/-command.js
+++ b/lib/commands/-command.js
@@ -30,7 +30,7 @@ module.exports = Command.extend({
     process.env.CORBER = true;
 
     let versions = getVersions(this.project.root);
-    this.isWithinProject = (versions.corber.project !== undefined);
+    this.isWithinProject = (versions.corber.project.required !== undefined);
 
     let disabled = _get(app, 'settings.disableEcAnalytics', false);
     let version = _get(app, 'project.addonPackages.corber.pkg.version');

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -12,14 +12,30 @@ module.exports = Command.extend({
   run(options) {
     this._super.apply(this, arguments);
 
-    let versions = getVersions(this.project.root);
-    logger.info(`corber (global): ${versions.corber.global}`);
+    let {
+      corber: {
+        global,
+        project: {
+          required,
+          installed
+        }
+      },
+      node
+    } = getVersions(this.project.root);
 
-    if (versions.corber.project) {
-      logger.info(`corber (project): ${versions.corber.project}`);
+    if (global) {
+      logger.info(`corber (global): ${global}`);
     }
 
-    logger.info(`node: ${versions.node}`);
+    if (required) {
+      logger.info(`corber (package.json): ${required}`);
+    }
+
+    if (installed) {
+      logger.info(`corber (node_modules): ${installed}`);
+    }
+
+    logger.info(`node: ${node}`);
 
     return Promise.resolve();
   }

--- a/lib/utils/get-versions.js
+++ b/lib/utils/get-versions.js
@@ -3,35 +3,42 @@ const getPackage = require('./get-package');
 const existsSync = require('./fs-utils').existsSync;
 
 module.exports = function getVersions(root) {
-  let versions = {
-    corber: {},
-    node: process.versions.node
+  let versions = {};
+  let globalPackagePath = path.join('..', '..', 'package.json');
+
+  if (existsSync(globalPackagePath)) {
+    versions.global = getPackage(globalPackagePath).version;
   }
 
-  let globalPackagePath = path.join('..', '..', 'package.json');
-  let globalPackage = getPackage(globalPackagePath);
-
-  versions.corber.global = globalPackage.version;
+  versions.project = {};
 
   if (root) {
     let projectPackagePath = path.join(root, 'package.json');
 
     if (existsSync(projectPackagePath)) {
-      let projectPackage = getPackage(projectPackagePath);
+      let { dependencies, devDependencies } = getPackage(projectPackagePath);
 
-      let dependenciesVersion;
-      if (projectPackage.dependencies) {
-        dependenciesVersion = projectPackage.dependencies.corber;
+      if (devDependencies && devDependencies.corber) {
+        versions.project.required = devDependencies.corber
+      } else if (dependencies && dependencies.corber) {
+        versions.project.required = dependencies.corber;
       }
 
-      let devDependenciesVersion;
-      if (projectPackage.devDependencies) {
-        devDependenciesVersion = projectPackage.devDependencies.corber;
-      }
+      let corberPackagePath = path.join(
+        root,
+        'node_modules',
+        'corber',
+        'package.json'
+      );
 
-      versions.corber.project = dependenciesVersion || devDependenciesVersion;
+      if (existsSync(corberPackagePath)) {
+        versions.project.installed = getPackage(corberPackagePath).version;
+      }
     }
   }
 
-  return versions;
+  return {
+    corber: versions,
+    node: process.versions.node
+  };
 };

--- a/node-tests/unit/commands/version-test.js
+++ b/node-tests/unit/commands/version-test.js
@@ -1,29 +1,28 @@
 const td          = require('testdouble');
 const mockProject = require('../../fixtures/corber-mock/project');
-
-const logger      = require('../../../lib/utils/logger');
 const contains    = td.matchers.contains;
-
-let versions, infoDouble, versionCmd;
+const root        = mockProject.project.root;
 
 describe('Version Command', () => {
+  let logger, getVersions;
+  let versionCmd;
+
   beforeEach(() => {
-    versions = {
+    logger = td.replace('../../../lib/utils/logger');
+    getVersions = td.replace('../../../lib/utils/get-versions');
+
+    td.when(getVersions(root)).thenReturn({
       corber: {
         global: '1.0.0',
-        project: '2.0.0'
+        project: {
+          required: '>2.0.0',
+          installed: '2.0.1'
+        }
       },
       node: '8.9.4'
-    };
-
-    td.replace('../../../lib/utils/get-versions', (root) => {
-      return versions;
     });
 
-    infoDouble = td.replace(logger, 'info');
-
     let VersionCmd = require('../../../lib/commands/version');
-
     versionCmd = new VersionCmd({
       project: mockProject.project
     });
@@ -36,22 +35,75 @@ describe('Version Command', () => {
   describe('run', () => {
     it('shows corber and node versions', () => {
       return versionCmd.run().then(() => {
-        td.verify(infoDouble('corber (global): 1.0.0'));
-        td.verify(infoDouble('corber (project): 2.0.0'));
-        td.verify(infoDouble('node: 8.9.4'));
+        td.verify(logger.info('corber (global): 1.0.0'));
+        td.verify(logger.info('corber (package.json): >2.0.0'));
+        td.verify(logger.info('corber (node_modules): 2.0.1'));
+        td.verify(logger.info('node: 8.9.4'));
       })
     });
 
-    context('when project version unavailable', () => {
+    context('when global version unavailable', () => {
       beforeEach(() => {
-        delete versions.corber.project;
+        td.when(getVersions(root)).thenReturn({
+          corber: {
+            project: {
+              required: '>2.0.0',
+              installed: '2.0.1'
+            }
+          },
+          node: '8.9.4'
+        });
       });
 
-      it('does not show project version', () => {
+      it('does not show global version', () => {
         return versionCmd.run().then(() => {
-          td.verify(infoDouble(contains('corber (project)')), { times: 0 });
+          td.verify(logger.info(contains('corber (global)')), { times: 0 });
         })
       });
-    })
+    });
+
+    context('when required version unavailable', () => {
+      beforeEach(() => {
+        td.when(getVersions(root)).thenReturn({
+          corber: {
+            global: '1.0.0',
+            project: {
+              installed: '2.0.1'
+            }
+          },
+          node: '8.9.4'
+        });
+      });
+
+      it('does not show required version', () => {
+        return versionCmd.run().then(() => {
+          td.verify(logger.info(contains('corber (package.json)')), {
+            times: 0
+          });
+        })
+      });
+    });
+
+    context('when installed version unavailable', () => {
+      beforeEach(() => {
+        td.when(getVersions(root)).thenReturn({
+          corber: {
+            global: '1.0.0',
+            project: {
+              required: '>2.0.0'
+            }
+          },
+          node: '8.9.4'
+        });
+      });
+
+      it('does not show installed version', () => {
+        return versionCmd.run().then(() => {
+          td.verify(logger.info(contains('corber (node_modules)')), {
+            times: 0
+          });
+        })
+      });
+    });
   });
 });

--- a/node-tests/unit/utils/get-versions-test.js
+++ b/node-tests/unit/utils/get-versions-test.js
@@ -1,75 +1,98 @@
 const td                 = require('testdouble');
 const expect             = require('../../helpers/expect');
 const path               = require('path');
-const fsUtils            = require('../../../lib/utils/fs-utils');
 const mockProject        = require('../../fixtures/corber-mock/project');
 const root               = mockProject.project.root;
-const globalPackagePath  = path.join('..', '..', 'package.json');
-const projectPackagePath = path.join(root, 'package.json');
 
-let packages, fileExists, getVersions;
+let globalPackagePath    = path.join('..', '..', 'package.json');
+let projectPackagePath   = path.join(root, 'package.json');
+let corberPackagePath    = path.join(root, 'node_modules', 'corber', 'package.json');
 
 describe('getVersions', () => {
+  let getPackage, fsUtils;
+  let getVersions;
+
   beforeEach(() => {
-    packages = {};
-    packages[globalPackagePath] = { version: '1.0.0' };
-    packages[projectPackagePath] = {
-      devDependencies: {
-        corber: '1.2.3'
-      }
-    };
-
-    td.replace('../../../lib/utils/get-package', (packagePath) => {
-      return packages[packagePath];
-    });
-
-    fileExists = {};
-    fileExists[projectPackagePath] = true;
-
-    td.replace(fsUtils, 'existsSync', (filePath) => {
-      return fileExists[filePath];
-    });
-
+    getPackage = td.replace('../../../lib/utils/get-package');
+    fsUtils = td.replace('../../../lib/utils/fs-utils');
     getVersions = require('../../../lib/utils/get-versions');
+
+    td.when(getPackage(globalPackagePath)).thenReturn({ version: '1.0.0' });
+    td.when(getPackage(projectPackagePath)).thenReturn({
+      devDependencies: {
+        corber: '~1.2.3'
+      }
+    });
+    td.when(getPackage(corberPackagePath)).thenReturn({ version: '1.2.5' })
+
+    td.when(fsUtils.existsSync(globalPackagePath)).thenReturn(true);
+    td.when(fsUtils.existsSync(projectPackagePath)).thenReturn(true);
+    td.when(fsUtils.existsSync(corberPackagePath)).thenReturn(true);
   });
 
   afterEach(() => {
     td.reset();
   });
 
-  it('reads the global corber version', () => {
+  it('reads global corber version', () => {
     let versions = getVersions(root);
     expect(versions.corber.global).to.equal('1.0.0');
   });
 
-  it('reads the project corber version', () => {
+  it('reads ./node_modules/corber/package.json version', () => {
     let versions = getVersions(root);
-    expect(versions.corber.project).to.equal('1.2.3');
+    expect(versions.corber.project.installed).to.equal('1.2.5');
   });
 
-  it('reads the node version', () => {
+  it('reads ./package.json corber version', () => {
+    let versions = getVersions(root);
+    expect(versions.corber.project.required).to.equal('~1.2.3');
+  });
+
+  it('reads node version', () => {
     let versions = getVersions(root);
     expect(versions.node).to.equal(process.versions.node);
   });
 
-  context('when corber is added as a full dependency', () => {
+  context('when project package.json does not exist', () => {
     beforeEach(() => {
-      delete packages[projectPackagePath].devDependencies;
+      td.when(fsUtils.existsSync(projectPackagePath)).thenReturn(false);
+    });
 
-      packages[projectPackagePath].dependencies = {
-        corber: '1.2.3'
-      };
+    it('does not contain a required version', () => {
+      let versions = getVersions(root);
+      expect(versions.corber.project.required).to.be.undefined;
+    });
+
+    it('does not contain an installed version', () => {
+      let versions = getVersions(root);
+      expect(versions.corber.project.installed).to.be.undefined;
     });
   });
 
-  context('when project package.json does not exist', () => {
+  context('when ./node_modules/corber/package.json does not exist', () => {
     beforeEach(() => {
-      fileExists[projectPackagePath] = false;
+      td.when(fsUtils.existsSync(corberPackagePath)).thenReturn(false);
     });
 
-    it('does not contain a project version', () => {
+    it('does not contain an installed version', () => {
       let versions = getVersions(root);
-      expect(versions.corber.project).to.be.undefined;
+      expect(versions.corber.project.installed).to.be.undefined;
     });
+  });
+
+  context('when corber belongs to package.json dependencies', () => {
+    beforeEach(() => {
+      td.when(getPackage(projectPackagePath)).thenReturn({
+        dependencies: {
+          corber: '~1.2.3'
+        }
+      });
+    });
+
+    it('returns the correct required version', () => {
+      let versions = getVersions(root);
+      expect(versions.corber.project.required).to.equal('~1.2.3');
+    })
   });
 });


### PR DESCRIPTION
Upgrades the version command to distinguish between project `package.json`, and project `./node_modules/corber/package.json` corber versions (when available). 

Example output:
```
[ ~/code/ember-app ] corber v
corber (global): 1.2.7
corber (package.json): ~1.2.6
corber (node_modules): 1.2.7
node: 6.11.2
```

Also improves testing.