### PR TITLE
Vue docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ _site
 yarn.lock
 .idea
 /node_modules
+
+/vendor
+/.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ DEPENDENCIES
   jekyll-livereload
 
 RUBY VERSION
-   ruby 2.3.4p301
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.1

--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,4 @@ kramdown:
   syntax_highlighter: rouge
   syntax_highlighter_opts:
     disable: true
+exclude: [vendor]

--- a/pages/frameworks/vue.md
+++ b/pages/frameworks/vue.md
@@ -3,7 +3,7 @@ layout: page
 title:  "Vue"
 ---
 
-Corber requires Vue projects to be made with `vue-cli`, which it automatically detects and runs with minimal configuration.
+Corber automatically detects and runs `vue-cli` projects with minimal configuration, but doesn't currently support non-`vue-cli` projects.
 
 First, install `corber-webpack-plugin`:
 

--- a/pages/frameworks/vue.md
+++ b/pages/frameworks/vue.md
@@ -3,23 +3,25 @@ layout: page
 title:  "Vue"
 ---
 
-Vue support is limited to [vue-cli](https://github.com/vuejs/vue-cli) Webpack users. Corber will detect vue-cli projects and run accordingly.
+Corber requires Vue projects to be made with `vue-cli`, which it automatically detects and runs with minimal configuration.
 
-The following changes to your Vue application are required:
-
-- In `config/index.js`, `assetsPublicPath` must not have a leading slash.
-- If you want to enable `cordova.js` and plugins in live reload, you will need to run:
+First, install `corber-webpack-plugin`:
 
 ```bash
   npm install corber-webpack-plugin --save-dev
 ```
 
-and then add the following to `build/webpack.dev.conf` plugins array:
+Then you'll need to add `corber-webpack-plugin` to your `vue.conf.js` file to enable live reloading. Below is a minimal `vue.conf.js` that you can use as a guide or to get the file started with:
 
 ```javascript
+const CorberWebpackPlugin = require('corber-webpack-plugin');
+
 module.exports = {
-  plugins: [new CorberWebpackPlugin()]
-};
+  baseUrl: './',
+  configureWebpack: {
+      plugins: [new CorberWebpackPlugin()]
+  }
+}
 ```
 
-The CLI will warn you if anything is missing.
+Now, you can run the [quickstart](/), and the CLI will warn you if your application requires any further configuration.


### PR DESCRIPTION
PR to change instructions for Vue to `vue-cli` v3 and greater. Includes a couple small changes to .gitignore and _config.yml to accommodate local bundle files.