### PR TITLE
Feature: Add hooks for `platform` command

### DIFF
--- a/lib/commands/platform.js
+++ b/lib/commands/platform.js
@@ -1,7 +1,9 @@
 const Command          = require('./-command');
 const SanitizeArgs     = require('../targets/cordova/validators/addon-args');
 const PlatformTask     = require('../targets/cordova/tasks/platform');
+const Hook             = require('../tasks/run-hook');
 const logger           = require('../utils/logger');
+const camelize         = require('../utils/string').camelize;
 const Promise          = require('rsvp').Promise;
 
 module.exports = Command.extend({
@@ -30,14 +32,25 @@ module.exports = Command.extend({
       project: this.project
     });
 
+    let hook = new Hook({
+      project: this.project
+    });
+
     return new Promise((resolve, reject) => {
       cordovaArgValidator.run().then((validated) => {
+        return hook.run(
+          camelize(`beforePlatform-${validated.action}`), options
+        ).then(() => validated);
+      }).then((validated) => {
         logger.info(
           'Preparing to ' + validated.action + ' platform ' + rawArgs
         );
 
-        return platform.run(validated.action, validated.name, options);
-      }).then(resolve).catch(function(err) {
+        return platform.run(validated.action, validated.name, options)
+          .then(() => validated);
+      }).then((validated) => (
+        hook.run(camelize(`afterPlatform-${validated.action}`))
+      )).then(resolve).catch(function(err) {
         logger.error(err);
         reject();
       });

--- a/lib/commands/platform.js
+++ b/lib/commands/platform.js
@@ -36,21 +36,27 @@ module.exports = Command.extend({
       project: this.project
     });
 
-    return new Promise((resolve, reject) => {
-      cordovaArgValidator.run().then((validated) => {
-        return hook.run(
-          camelize(`beforePlatform-${validated.action}`), options
-        ).then(() => validated);
-      }).then((validated) => {
-        logger.info(
-          'Preparing to ' + validated.action + ' platform ' + rawArgs
-        );
+    function beforePlatform(action) {
+      return hook.run(camelize(`beforePlatform-${action}`), options);
+    }
 
-        return platform.run(validated.action, validated.name, options)
-          .then(() => validated);
-      }).then((validated) => (
-        hook.run(camelize(`afterPlatform-${validated.action}`))
-      )).then(resolve).catch(function(err) {
+    function afterPlatform(action) {
+      return hook.run(camelize(`afterPlatform-${action}`), options);
+    }
+
+    return new Promise((resolve, reject) => {
+      cordovaArgValidator.run().then((validated) => (
+        beforePlatform(validated.action).then(() => validated)
+      )).then((validated) => {
+        logger.info(`Preparing to ${validated.action} platform ${rawArgs}`);
+        return platform.run(
+          validated.action,
+          validated.name,
+          options
+        ).then(() => validated);
+      })
+      .then(({ action }) => afterPlatform(action))
+      .then(resolve).catch(function(err) {
         logger.error(err);
         reject();
       });

--- a/node-tests/unit/commands/platform-test.js
+++ b/node-tests/unit/commands/platform-test.js
@@ -1,34 +1,74 @@
 const td              = require('testdouble');
+const Promise         = require('rsvp');
 const mockProject     = require('../../fixtures/corber-mock/project');
 const mockAnalytics   = require('../../fixtures/corber-mock/analytics');
-
-const setupCommand = function() {
-  let PlatformCmd     = require('../../../lib/commands/platform');
-
-  let platform = new PlatformCmd({
-    project: mockProject.project,
-    analytics: mockAnalytics
-  });
-  return platform;
-};
+const expect          = require('../../helpers/expect');
 
 describe('Platform Command', function() {
+  let tasks;
+
   afterEach(function() {
     td.reset();
   });
 
+  const setupCommand = function() {
+    let HookTask        = td.replace('../../../lib/tasks/run-hook');
+    let PlatformCmd     = require('../../../lib/commands/platform');
+
+    tasks = [];
+
+    td.replace(HookTask.prototype, 'run', function(hookName, options) {
+      expect(options, `${hookName} options`).to.be.an('object');
+      tasks.push(`hook ${hookName}`);
+      return Promise.resolve();
+    });
+
+    let platform = new PlatformCmd({
+      project: mockProject.project,
+      analytics: mockAnalytics
+    });
+    return platform;
+  };
+
   it('validates and calls Platform.run', function() {
     let PlatformTask = td.replace('../../../lib/targets/cordova/tasks/platform');
-    let runDouble = td.replace(PlatformTask.prototype, 'run');
+
+    td.replace(PlatformTask.prototype, 'run', function(action, name) {
+      tasks.push(`${action} ${name}`);
+      return Promise.resolve();
+    });
 
     let command = setupCommand();
 
     return command.run({}, ['platform', 'add', 'ios']).then(function() {
+      expect(tasks).to.deep.equal([
+        'hook beforePlatformAdd',
+        'add platform',
+        'hook afterPlatformAdd'
+      ]);
+
       td.verify(new PlatformTask({
         project: mockProject.project
       }));
+    });
+  });
 
-      td.verify(runDouble('add', 'platform', {}));
+  it('runs before/after hooks for Platform.run remove', function() {
+    let PlatformTask = td.replace('../../../lib/targets/cordova/tasks/platform');
+
+    td.replace(PlatformTask.prototype, 'run', (action, name) => {
+      tasks.push(`${action} ${name}`);
+      return Promise.resolve();
+    });
+
+    let command = setupCommand();
+
+    return command.run({}, ['platform', 'remove', 'ios']).then(() => {
+      expect(tasks).to.deep.equal([
+        'hook beforePlatformRemove',
+        'remove platform',
+        'hook afterPlatformRemove'
+      ]);
     });
   });
 });


### PR DESCRIPTION
This PR adds the ability to execute the following hooks:
- beforePlatformAdd
- afterPlatformAdd
- beforePlatformRemove
- afterPlatformRemove

It follows the corber convention of executing hooks established with `beforeBuild` & `afterBuild`.