### PR TITLE
Fix/Open projects with spaces in app name

### DIFF
--- a/lib/utils/open-app-command.js
+++ b/lib/utils/open-app-command.js
@@ -4,14 +4,16 @@
   is resolved, original file can be seen here:
   https://github.com/pwnall/node-open/blob/0c3ad272bfbc163cce8806e64630c623a9cfd8f4/lib/open.js
 */
+
+const escapeDoubleQuotes = (str) => str.replace(/"/g, '\\\"');
+
 module.exports = function(target, appName) {
   let opener;
 
   switch (process.platform) {
     case 'darwin':
       if (appName) {
-
-        opener = 'open -a "' + appName + '"';
+        opener = 'open -a "' + escapeDoubleQuotes(appName) + '"';
       } else {
         opener = 'open';
       }
@@ -20,14 +22,14 @@ module.exports = function(target, appName) {
       // if the first parameter to start is quoted, it uses that as the title
       // so we pass a blank title so we can quote the file we are opening
       if (appName) {
-        opener = 'start "" "' + appName + '"';
+        opener = 'start "" "' + escapeDoubleQuotes(appName) + '"';
       } else {
         opener = 'start';
       }
       break;
     default:
       if (appName) {
-        opener = appName;
+        opener = escapeDoubleQuotes(appName);
       } else {
         // use Portlands xdg-open everywhere else
         opener = 'xdg-open';
@@ -39,5 +41,5 @@ module.exports = function(target, appName) {
     opener = 'sudo -u ' + process.env.SUDO_USER + ' ' + opener;
   }
 
-  return opener + ' ' + target;
+  return `${opener} "${escapeDoubleQuotes(target)}"`
 };

--- a/node-tests/unit/utils/open-app-command-test.js
+++ b/node-tests/unit/utils/open-app-command-test.js
@@ -1,0 +1,53 @@
+const expect = require('../../helpers/expect');
+const openAppCommand = require('../../../lib/utils/open-app-command');
+
+describe('openAppCommand util', () => {
+  context('platform is darwin', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin'
+      });
+    });
+
+    it('returns a valid open command', () => {
+      let command = openAppCommand('my app');
+      expect(command).to.equal('open "my app"');
+    });
+
+    it('allows a custom opener', () => {
+      let command = openAppCommand('my app', 'my opener');
+      expect(command).to.equal('open -a "my opener" "my app"');
+    });
+  });
+
+  context('platform is win32', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32'
+      });
+    });
+
+    it('returns a valid open command', () => {
+      let command = openAppCommand('my app');
+      expect(command).to.equal('start "my app"');
+    });
+
+    it('allows a custom opener', () => {
+      let command = openAppCommand('my app', 'my opener');
+      expect(command).to.equal('start "" "my opener" "my app"');
+    });
+  });
+
+  context('platform is something weird', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {
+        value: 'mysteryOS'
+      });
+    });
+    it('returns an open command using xdg-open', () => {
+      let command = openAppCommand('my app');
+      expect(command).to.equal('xdg-open "my app"');
+    });
+  });
+});
+


### PR DESCRIPTION
When the `open-app-command` util was adapted from its [original source](https://github.com/pwnall/node-open/blob/0c3ad272bfbc163cce8806e64630c623a9cfd8f4/lib/open.js
), the code was copied without the accompanying `escape` function. This would not have raised any errors initially, because `escape` is also a native function (albeit for a different purpose). Later, these calls were removed (presumably because of the problematic native encoding), but no provision was made for spaces in paths.

This PR restores the escaping, renames the escape function to obviate confusion, and adds tests.

Addresses #497