### PR TITLE
add space between 'corber' in error validation message

### DIFF
--- a/lib/targets/cordova/utils/cordova-validator.js
+++ b/lib/targets/cordova/utils/cordova-validator.js
@@ -49,7 +49,7 @@ function CordovaValidator(opts) {
 /* eslint-disable max-len */
 CordovaValidator.prototype.makeError = function(error) {
   let message = chalk.red('* cordova ' + this.type + ' ' +  this.desiredKeyName + ' is missing or not installed: \n');
-  message += chalk.grey('You probably need to run corber' + this.type + ' add ' + this.desiredKeyName + '. ');
+  message += chalk.grey('You probably need to run corber ' + this.type + ' add ' + this.desiredKeyName + '. ');
   message += chalk.grey('cordova error: ' + error + '\n');
   return message;
 };


### PR DESCRIPTION
I saw this message :
```
Corber: Validation error(s)

* cordova plugin cordova-plugin-whitelist is missing or not installed:
You probably need to run corberplugin add cordova-plugin-whitelist. cordova error: Not found in platform.json.
```

Being dumb, I typed `corberplugin` into my terminal, which is not a
command. Hopefully this space will clarify that its `corber plugin`.