### PR TITLE
Fix typo of signing properties option

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -48,8 +48,8 @@ module.exports = Command.extend({
     { name: 'cdv-min-sdk-version',                 type: String },
     { name: 'cdv-build-tools-version',             type: String },
     { name: 'cdv-compile-sdk-version',             type: String },
-    { name: 'cdv-debug-sigining-properties-file',  type: String },
-    { name: 'cdv-release-sigining-properties-file', type: String }
+    { name: 'cdv-debug-signing-properties-file',  type: String },
+    { name: 'cdv-release-signing-properties-file', type: String }
 
   ],
   /* eslint-enable max-len */


### PR DESCRIPTION
This simply fixes a typo of the word `signing` in the options for corber build