### PR TITLE
fix(plugin/link-flag): link is a boolean option

### DIFF
--- a/lib/commands/plugin.js
+++ b/lib/commands/plugin.js
@@ -20,7 +20,7 @@ module.exports = Command.extend({
     { name: 'noregistry',           type: Boolean, default: false },
     { name: 'nohooks',              type: Boolean, default: false },
     { name: 'browserify',           type: Boolean, default: false },
-    { name: 'link',                 type: String,  default: undefined },
+    { name: 'link',                 type: Boolean, default: false },
     { name: 'force',                type: Boolean, default: false }
   ],
   /* eslint-enable max-len */

--- a/node-tests/unit/commands/plugin-test.js
+++ b/node-tests/unit/commands/plugin-test.js
@@ -41,6 +41,16 @@ describe('Plugin Command', function() {
     });
   });
 
+  it('passes the link flag', function() {
+    let plugin = stubCommand();
+    let rawDouble = td.replace(CdvRawTask.prototype, 'run');
+
+    var opts = { link: true };
+    return plugin.run(opts, ['add', 'cordova-plugin']).then(function() {
+      td.verify(rawDouble('add', 'cordova-plugin', contains({ link: true })));
+    });
+  });
+
   it('defaults fetch to true', function() {
     let plugin = stubCommand();
     let rawDouble = td.replace(CdvRawTask.prototype, 'run');


### PR DESCRIPTION
This PR corrects the passing of the `link` option to Cordova-Lib when invoking `corber plugin add <my-plugin> --link`.

The underlying issue was that the `link` argument was configured as a string, when it is in fact a boolean (see https://github.com/apache/cordova-cli/blob/8a112b0b44a44958c9d646f73c5c09ded105654d/src/cli.js#L469). Thus, the `--link` argument was passing an empty string, which was then coerced to `false` in a conditional.

Resolves issue #398.