### PR TITLE
feat(logging): first pass at warnings clean-up

### DIFF
--- a/lib/commands/cordova.js
+++ b/lib/commands/cordova.js
@@ -13,10 +13,11 @@ module.exports = Command.extend({
     this._super.apply(this, arguments);
 
     logger.warn(
-      'DEPRECATION WARNING (corber): corber cdv proxy syntax has been deprecated in favor of corber proxy\n' +
-      'The prior proxy command was "corber cdv $COMMAND" \n' +
-      'To ease confusion this is now "cordova proxy $COMMAND". No other changes are required. \n' +
-      'So corber cdv run would now be corber proxy run \n'
+      '(DEPRECATION) The Cordova proxy command\n' +
+      '\tcorber cdv <command>\n' +
+      'has been deprecated in favour of\n' +
+      '\tcorber proxy <command>\n' +
+      'For example, "corber cdv run" is now "corber proxy run".'
     );
   }
 });

--- a/lib/frameworks/ember/validators/corber-ember.js
+++ b/lib/frameworks/ember/validators/corber-ember.js
@@ -3,7 +3,6 @@ const getPackage = require('../../../utils/get-package');
 const logger     = require('../../../utils/logger');
 const path       = require('path');
 const RSVP       = require('rsvp');
-const chalk      = require('chalk');
 
 module.exports = Task.extend({
   root: undefined,
@@ -31,14 +30,11 @@ module.exports = Task.extend({
   },
 
   buildWarningMessage(packagePath) {
-    return chalk.yellow(`
-      Could not find corber-ember-livereload in ${packagePath}.
-      This means the cordova.js & plugins will not be available in livereload.
-
-      To fix, run:
-      ember install corber-ember-livereload
-
-      more: http://corber.io/pages/frameworks/ember`
-    );
+    return `Could not find corber-ember-livereload in ${packagePath}. ` +
+      'This means that cordova.js & plugins will not be available in ' +
+      'livereload.\n\n' +
+      'To fix, run:\n' +
+      '\tember install corber-ember-livereload\n\n' +
+      'Read more: http://corber.io/pages/frameworks/ember';
   }
 });

--- a/lib/targets/cordova/validators/allow-navigation.js
+++ b/lib/targets/cordova/validators/allow-navigation.js
@@ -5,17 +5,17 @@ const logger           = require('../../../utils/logger');
 const getCordovaConfig = require('../utils/get-config');
 
 const UNSAFE_PRODUCTION_VALUE =
-  chalk.yellow('Your corber/cordova/config.xml file has set the' +
+  chalk.yellow('Your corber/cordova/config.xml file has set the ' +
     'following flag:\n') +
   chalk.grey('\t<allow-navigation href="${allowNavigation}" />\n') +
-  chalk.yellow('This is necessary for device live-reload to work,\n' +
-    'but is unsafe and should not be used in production.\n');
+  chalk.yellow('This is necessary for device live-reload to work, ' +
+    'but is unsafe and should not be used in production.');
 
 const LIVE_RELOAD_CONFIG_NEEDED =
   chalk.red('* corber/cordova/config.xml needs: \n') +
   chalk.grey('<allow-navigation href="*" />\n') +
-  chalk.grey('This is unsafe and should not be used in production,\n' +
-    'but is necessary for device live-reload to work.\n');
+  chalk.grey('This is unsafe and should not be used in production, ' +
+    'but is necessary for device live-reload to work.');
 
 /*
  * allow-navigation is considered unsafe when:

--- a/lib/tasks/create-project.js
+++ b/lib/tasks/create-project.js
@@ -58,13 +58,12 @@ module.exports = Task.extend({
   },
 
   warnCustomFramework() {
-    logger.warn(`
-      Your framework type (Ember/Vue/Glimmer was not identified.
-      Initting with a custom framework type.
-      Required framework functions are in corber/config/framework.js
-      - You will need to implement these shell functions yourself.
-      \n
-      If you expected a framework type to be identified, please open an issue`
+    logger.warn(
+      'Your framework type (e.g. Ember/Vue/Glimmer) was not identified; ' +
+      'initializing with a custom framework type. Required framework ' +
+      'functions are located in corber/config/framework.js--you will need to ' +
+      'implement these shell functions yourself.\n\n' +
+      'If you expected a framework type to be identified, please open an issue.'
     );
   },
 

--- a/lib/utils/corber-error.js
+++ b/lib/utils/corber-error.js
@@ -9,7 +9,7 @@ const CorberError = function(content) {
 
 CorberError.prototype = Object.create(Error.prototype);
 CorberError.prototype.toString = function() {
-  return `Corber: ${this.message}`;
+  return `${this.message}`;
 };
 CorberError.constructor = CorberError;
 

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -25,8 +25,7 @@ module.exports = {
     if (!this.shouldLog('warn')) {
       return;
     }
-    let message = 'WARNING: corber \n';
-    message += content;
+    let message = `WARNING: ${content}\n`;
     console.log(chalk.yellow(message));
   },
 

--- a/lib/validators/webpack-plugin.js
+++ b/lib/validators/webpack-plugin.js
@@ -1,7 +1,6 @@
 const Task             = require('../tasks/-task');
 const logger           = require('../utils/logger');
 const Promise          = require('rsvp').Promise;
-const chalk            = require('chalk');
 const find             = require('lodash').find;
 
 module.exports = Task.extend({
@@ -11,19 +10,18 @@ module.exports = Task.extend({
   configPath: undefined,
 
   warnMsg() {
-    return logger.warn(chalk.yellow(`
-      Could not find corber-webpack-plugin in ${this.configPath}.
-      This means the cordova.js & plugins will not be available in livereload.
+    let message =
+      `Could not find corber-webpack-plugin in ${this.configPath}. This means` +
+      ' the cordova.js & plugins will not be available in livereload.\n\n' +
+      'Ensure corber-webpack-plugin has been installed with:\n' +
+      '\tyarn add corber-webpack-plugin --dev\n' +
+      'or\n' +
+      '\tnpm install corber-webpack-plugin --save-dev\n' +
+      `and the ${this.configPath} configureWebpack.plugins array contains ` +
+      'new CorberWebpackPlugin().\n\n' +
+      `Read More: http://corber.io/pages/frameworks/${this.framework}`;
 
-      Ensure corber-webpack-plugin has been installed with:
-        yarn add corber-webpack-plugin --dev
-      or
-        npm install corber-webpack-plugin --save-dev
-      and the ${this.configPath} configureWebpack.plugins array contains
-        new CorberWebpackPlugin()
-
-      Read More: http://corber.io/pages/frameworks/${this.framework}`
-    ));
+    logger.warn(message);
   },
 
   includesWebpack(plugins) {


### PR DESCRIPTION
Nothing too ambitious here, just a first pass at tidying up the yellow warning messages shown during corber commands.

Changes:
- render warnings as `WARNING: ${warning}` rather than `WARNING: corber\n${warning}`
- apply terminating newline in logger call, eliminate from string constructions
- clean up newlines in various longer warnings
- eliminate redundant use of `chalk.yellow` for warnings