### PR TITLE
fix(raw): use fork for script runner; resolves windows issues

### DIFF
--- a/lib/targets/cordova/tasks/raw.js
+++ b/lib/targets/cordova/tasks/raw.js
@@ -28,7 +28,8 @@ module.exports = Task.extend({
     return spawn(runnerPath, [serializedArgs], {}, {
       onStdout: this.onStdout,
       onStderr: this.onStderr,
-      cwd: getCordovaPath(this.project)
+      cwd: getCordovaPath(this.project),
+      fork: true
     });
   }
 });

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -4,7 +4,7 @@ const childProcess     = require('child_process');
 const EXIT_CODE_NOT_FOUND = 127;
 
 module.exports = function(command, args = [], processOpts = {}, opts = {}) {
-  let { onStderr, onStdout, cwd } = opts;
+  let { onStderr, onStdout, cwd, fork } = opts;
   let processPath;
 
   if (cwd) {
@@ -13,7 +13,17 @@ module.exports = function(command, args = [], processOpts = {}, opts = {}) {
   }
 
   let deferred = RSVP.defer();
-  let spawned = childProcess.spawn(command, args, processOpts);
+
+  let spawned;
+  if (fork) {
+    // pipe fork output to stdout/stderr streams
+    processOpts.silent = true;
+
+    spawned = childProcess.fork(command, args, processOpts);
+  } else {
+    spawned = childProcess.spawn(command, args, processOpts);
+  }
+
   let stdoutLines = [];
   let stderrLines = [];
 


### PR DESCRIPTION
This PR fixes #569.

The underlying issue is that `childProcess.spawn` is unsuitable for executing node bang scripts on Windows (e.g. `cordova-lib-runner`, which is used for raw commands like platform). In such a case, `childProcess.fork` is a working drop-in replacement that doesn't rely on the OS shell.