### PR TITLE
Ensure a path is present when finding the apkName.

### DIFF
--- a/lib/targets/android/utils/apk-path.js
+++ b/lib/targets/android/utils/apk-path.js
@@ -29,10 +29,10 @@ module.exports = function(root, isDebug) {
   lookups.push(spawn('ls', ['-r', studioPath]));
 
   return RSVP.allSettled(lookups).then(function(promises) {
-    if (promises[0].state === 'fulfilled') {
+    if (promises[0].state === 'fulfilled' && promises[0].value.stdout) {
       let apkName = findApk(promises[0].value.stdout);
       return path.join(gradlePath, apkName);
-    } else if (promises[1].state === 'fulfilled') {
+    } else if (promises[1].state === 'fulfilled' && promises[1].value.stdout) {
       let apkName = findApk(promises[1].value.stdout);
       return path.join(studioPath, apkName);
     } else {


### PR DESCRIPTION
I was getting this error when running `corber start` for android: 

```
- stack: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type undefined
    at assertPath (path.js:39:11)
    at Object.join (path.js:1157:7)
    at /usr/local/lib/node_modules/corber/lib/targets/android/utils/apk-path.js:34:19
    at tryCatcher (/usr/local/lib/node_modules/corber/node_modules/rsvp/dist/rsvp.js:323:19)
    at invokeCallback (/usr/local/lib/node_modules/corber/node_modules/rsvp/dist/rsvp.js:495:31)
    at publish (/usr/local/lib/node_modules/corber/node_modules/rsvp/dist/rsvp.js:481:7)
    at flush (/usr/local/lib/node_modules/corber/node_modules/rsvp/dist/rsvp.js:2402:5)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```

After looking and logging in `apk-path.js`, `promises[0].state` was being set to `fulfilled`, but `promises[0].value.stdout` was set to a blank string (and had an error in `promises[0].value.stderr`). This resolves the issue.