### PR TITLE
Increase timeout for build command tests

### DIFF
--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -179,4 +179,4 @@ describe('Build Command', () => {
       expect(process.env.CORBER_PLATFORM).to.equal('ios');
     });
   });
-});
+}).timeout(10000);


### PR DESCRIPTION
When running tests on Node 10, Travis times out during the `beforeEach` block for the first test in the suite. The following tests usually pass, presumably due to caching.