### PR TITLE
Increase Mocha timeout

### DIFF
--- a/node-tests/unit/commands/build-test.js
+++ b/node-tests/unit/commands/build-test.js
@@ -213,4 +213,4 @@ describe('Build Command', () => {
       expect(process.env.CORBER_PLATFORM).to.equal('ios');
     });
   });
-}).timeout(10000);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --harmony --require babel-core/register \"node-tests/**/*-test.js\""
+    "test": "./node_modules/.bin/mocha --harmony --require babel-core/register --timeout 10000 \"node-tests/**/*-test.js\""
   },
   "engines": {
     "node": ">=4.5"


### PR DESCRIPTION
Tests are failing occasionally because the very first test (which does not benefit from caching) times out. 