### PR TITLE
fix(start.js): pass build options to beforeBuild and afterBuild hooks

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -225,7 +225,7 @@ module.exports = Command.extend({
           project
         });
 
-        return runHook('beforeBuild', {}, hookOptions);
+        return runHook('beforeBuild', opts, hookOptions);
       })
       .then(() => editXml.addNavigation(project, reloadUrl))
       .then(() => cdvTarget.validateServe())
@@ -233,7 +233,7 @@ module.exports = Command.extend({
       .then(() => createLRShell.run(reloadUrl))
       .then(() => prepare.run({ platforms: [device.platform] }))
       .then(() => platformTarget.build())
-      .then(() => runHook('afterBuild', {}, hookOptions))
+      .then(() => runHook('afterBuild', opts, hookOptions))
       .then(() => platformTarget.run())
       .then(() => framework.serve(opts))
       .then(() => editXml.removeNavigation(project, reloadUrl))


### PR DESCRIPTION
In reference to issue #624 