### PR TITLE
eslint fixes for Ember

### DIFF
--- a/lib/tasks/create-project.js
+++ b/lib/tasks/create-project.js
@@ -2,6 +2,7 @@ const Promise          = require('rsvp').Promise;
 const Task             = require('./-task');
 const CreateCordova    = require('../targets/cordova/tasks/create-project');
 const UpdateGitIgnore  = require('../tasks/update-gitignore');
+const ESLintIgnore     = require('../tasks/eslintignore');
 const InstallCorber    = require('../tasks/install-project-corber');
 const camelize         = require('../utils/string').camelize;
 const path             = require('path');
@@ -83,6 +84,11 @@ module.exports = Task.extend({
       ui: this.ui
     });
 
+    let eslintIgnore = new ESLintIgnore({
+      project: this.project,
+      ui: this.ui
+    });
+
     let installCorber = new InstallCorber({
       rootPath: this.project.root,
     });
@@ -90,6 +96,7 @@ module.exports = Task.extend({
     return this.initDirs(this.project)
     .then(() => create.run())
     .then(() => updateGitIgnore.run())
+    .then(() => eslintIgnore.run())
     .then(() => installCorber.run())
     .then(() => {
       let framework = requireFramework(this.project);

--- a/lib/tasks/eslintignore.js
+++ b/lib/tasks/eslintignore.js
@@ -1,0 +1,44 @@
+const Task            = require('./-task');
+const fsUtils         = require('../utils/fs-utils');
+const logger          = require('../utils/logger');
+const includes        = require('lodash').includes;
+
+const ignores = [
+  'corber/cordova',
+];
+
+const addLine = function(contents, path) {
+  return '\n' + path;
+};
+
+const addIfNew = function(contents, path) {
+  if (includes(contents, path) === false) {
+    return addLine(contents, path);
+  } else {
+    return '';
+  }
+};
+
+module.exports = Task.extend({
+  project: undefined,
+
+  run() {
+    return fsUtils.read('.eslintignore', { encoding: 'utf8' })
+      .then((contents) => {
+        logger.info('corber: updating .eslintignore');
+
+        this.eslintIgnore(contents);
+      })
+      .catch(() => {});
+  },
+
+  eslintIgnore(contents) {
+    contents += addIfNew(contents, '\n# corber');
+
+    ignores.forEach(function(ignore) {
+      contents += addIfNew(contents, ignore);
+    });
+
+    return fsUtils.write('.eslintignore', contents);
+  }
+});

--- a/lib/templates/frameworks/ember.js
+++ b/lib/templates/frameworks/ember.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const EmberFramework = require('corber/lib/frameworks/ember/framework');
 
 module.exports = EmberFramework.extend({

--- a/lib/templates/frameworks/glimmer.js
+++ b/lib/templates/frameworks/glimmer.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 const EmberFramework = require('corber/lib/frameworks/ember/framework');
 
 module.exports = EmberFramework.extend({

--- a/node-tests/unit/tasks/eslintignore-test.js
+++ b/node-tests/unit/tasks/eslintignore-test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+var td              = require('testdouble');
+var mockProject     = require('../../fixtures/corber-mock/project');
+var fsUtils         = require('../../../lib/utils/fs-utils');
+var Promise         = require('rsvp');
+
+var expect          = require('../../helpers/expect');
+
+describe('Update eslintignore Task', function() {
+  var expectedContent = '';
+
+  var createTask = function(ignoreStub) {
+    td.replace(fsUtils, 'read', function() {
+      return Promise.resolve(ignoreStub);
+    });
+
+    var ESLintIgnore = require('../../../lib/tasks/eslintignore');
+    return new ESLintIgnore({
+      project: mockProject.project
+    });
+  };
+
+  beforeEach(function() {
+    expectedContent = '\n\n' +
+      '# corber\n' +
+      'corber/cordova';
+  });
+
+  afterEach(function() {
+    td.reset();
+  });
+
+  it('attempts to write ignore data to .eslintignore', function() {
+    var writeContent;
+
+    td.replace(fsUtils, 'write', function(path, content) {
+      writeContent = content;
+      return Promise.resolve();
+    });
+
+    var task = createTask('');
+    return task.run().then(function() {
+      expect(writeContent).to.equal(expectedContent);
+    });
+  });
+
+  it('returns if .eslintignore does not exist', function() {
+    var writeContent;
+    var task = createTask('');
+
+    td.replace(fsUtils, 'read', function() {
+      return Promise.reject();
+    });
+
+    td.replace(fsUtils, 'write', function(path, content) {
+      writeContent = content;
+      return Promise.resolve();
+    });
+
+    return task.run().catch(function() {
+      expect(writeContent).to.equal(undefined);
+    });
+  });
+
+  it('does not clear existing content', function() {
+    var writeContent;
+
+    td.replace(fsUtils, 'write', function(path, content) {
+      writeContent = content;
+      return Promise.resolve();
+    });
+
+    var task = createTask('dist/');
+    return task.run().then(function() {
+      expect(writeContent).to.equal('dist/' + expectedContent);
+    });
+  });
+
+  it('does not duplicate content', function() {
+    var writeContent;
+
+    td.replace(fsUtils, 'write', function(path, content) {
+      if (path === '.eslintignore') {
+        writeContent = content;
+      }
+      return Promise.resolve();
+    });
+
+    var expected = 'dist/' + expectedContent;
+    var task = createTask(expected);
+    return task.run().then(function() {
+      expect(writeContent).to.equal(expected);
+    });
+  });
+});


### PR DESCRIPTION
1. Since eslint is built in for Ember, any generated files should pass eslint by default. Currently a new Ember project after `corber init` has `yarn lint:js` failing because of corber/config/framework.js – adding `/* eslint-env node */` fixes this

2. Similarly, a new Ember project after `corber init` has `yarn lint:js` taking forever because it's scanning all files in /corber/cordova, including node_modules. `corber init` should add `/corber/cordova` to .eslintignore if it exists (it exists by default on Ember 3.2+). If it does not exist, nothing happens.

Let me know if this helps or needs more work. I've added some tests but I'm not sure how to test it out manually on a new project. 