### PR TITLE
Add packageType to the list of flags android builds understand and can parse

### DIFF
--- a/lib/targets/cordova/utils/parse-build-flags.js
+++ b/lib/targets/cordova/utils/parse-build-flags.js
@@ -29,7 +29,8 @@ const ANDROID_OPTS = [
   'cdvDebugSigningPropertiesFile',
   'cdvMinSdkVersion',
   'cdvBuildToolsVersion',
-  'cdvCompileSdkVersion'
+  'cdvCompileSdkVersion',
+  'packageType'
 ];
 
 module.exports = function(platform, options) {


### PR DESCRIPTION
This allows Corber to perform bundle/aap builds for android:
https://github.com/apache/cordova-android/pull/764