### PR TITLE
Fix cordova lib logging

### DIFF
--- a/bin/cordova-lib-runner
+++ b/bin/cordova-lib-runner
@@ -2,6 +2,10 @@
 
 const cordovaLib = require('cordova-lib');
 
+// hook cordova-cli style logging up, corber will drop stdout without --verbose
+cordovaLib.cordova.on('log', console.log);
+cordovaLib.cordova.on('warn', console.error);
+
 // `lib/targets/cordova/tasks/raw.js` serializes all arguments into a single
 // string argument; this allow objects to be passed (e.g. options)
 let args = JSON.parse(process.argv[2]);

--- a/lib/commands/proxy.js
+++ b/lib/commands/proxy.js
@@ -22,8 +22,8 @@ module.exports = Command.extend({
     'emulate'
   ],
 
-  onStdout: (data) => logger.info(data),
-  onStderr: (data) => logger.error(data),
+  onStdout: (data) => logger.stdout(data),
+  onStderr: (data) => logger.stderr(data),
 
   validateAndRun(rawArgs) {
     let warning;

--- a/lib/targets/cordova/tasks/open-app.js
+++ b/lib/targets/cordova/tasks/open-app.js
@@ -13,8 +13,8 @@ module.exports = Task.extend({
   platform: undefined,
   project: undefined,
 
-  onStdout: (data) => logger.info(data),
-  onStderr: (data) => logger.error(data),
+  onStdout: (data) => logger.stdout(data),
+  onStderr: (data) => logger.stderr(data),
 
   run() {
     return this.getProjectFilePath(this.platform, this.project)

--- a/lib/targets/cordova/tasks/raw.js
+++ b/lib/targets/cordova/tasks/raw.js
@@ -15,8 +15,8 @@ module.exports = Task.extend({
   api: undefined,
 
   // hide all cordova-lib stdout unless `--verbose` flag is set explicitly
-  onStdout: (data) => logger.verbose(data),
-  onStderr: (data) => logger.error(data),
+  onStdout: (data) => logger.stdoutVerbose(data),
+  onStderr: (data) => logger.stderr(data),
 
   run(...args) {
     args.unshift(this.api);

--- a/lib/tasks/bash.js
+++ b/lib/tasks/bash.js
@@ -8,8 +8,8 @@ module.exports = Task.extend({
   options: undefined,
   cwd: undefined,
 
-  onStdout: (data) => logger.info(data),
-  onStderr: (data) => logger.error(data),
+  onStdout: (data) => logger.stdout(data),
+  onStderr: (data) => logger.stderr(data),
 
   run() {
     let options = defaults(this.options, {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -43,6 +43,24 @@ module.exports = {
     return error;
   },
 
+  stdoutVerbose(data) {
+    if (!this.shouldLog('verbose')) {
+      return;
+    }
+    process.stdout.write(data);
+  },
+
+  stdout(data) {
+    if (!this.shouldLog('info')) {
+      return;
+    }
+    process.stdout.write(data);
+  },
+
+  stderr(data) {
+    process.stderr.write(data);
+  },
+
   getLogLevel() {
     return this.logLevel;
   },

--- a/node-tests/unit/targets/cordova/tasks/raw-test.js
+++ b/node-tests/unit/targets/cordova/tasks/raw-test.js
@@ -81,11 +81,14 @@ describe('Cordova Raw Task', () => {
     // simulate standard output from wrapping cordova process
     captor.value.onStdout('foo');
 
-    td.verify(logger.verbose('foo'), { times: 1 });
+    td.verify(logger.verbose('foo'), { times: 0 });
     td.verify(logger.info('foo'), { times: 0 });
     td.verify(logger.success('foo'), { times: 0 });
     td.verify(logger.warn('foo'), { times: 0 });
     td.verify(logger.error('foo'), { times: 0 });
+    td.verify(logger.stdoutVerbose('foo'), { times: 1 });
+    td.verify(logger.stdout('foo'), { times: 0 });
+    td.verify(logger.stderr('foo'), { times: 0 });
 
     deferred.resolve();
 
@@ -108,7 +111,10 @@ describe('Cordova Raw Task', () => {
     td.verify(logger.info('foo'), { times: 0 });
     td.verify(logger.success('foo'), { times: 0 });
     td.verify(logger.warn('foo'), { times: 0 });
-    td.verify(logger.error('foo'), { times: 1 });
+    td.verify(logger.error('foo'), { times: 0 });
+    td.verify(logger.stdoutVerbose('foo'), { times: 0 });
+    td.verify(logger.stdout('foo'), { times: 0 });
+    td.verify(logger.stderr('foo'), { times: 1 });
 
     deferred.resolve();
 

--- a/node-tests/unit/tasks/bash-test.js
+++ b/node-tests/unit/tasks/bash-test.js
@@ -72,10 +72,13 @@ describe('Bash Task', () => {
     onStdout('foo');
 
     td.verify(logger.verbose('foo'), { times: 0 });
-    td.verify(logger.info('foo'), { times: 1 });
+    td.verify(logger.info('foo'), { times: 0 });
     td.verify(logger.success('foo'), { times: 0 });
     td.verify(logger.warn('foo'), { times: 0 });
     td.verify(logger.error('foo'), { times: 0 });
+    td.verify(logger.stdoutVerbose('foo'), { times: 0 });
+    td.verify(logger.stdout('foo'), { times: 1 });
+    td.verify(logger.stderr('foo'), { times: 0 });
 
     deferred.resolve();
 
@@ -101,7 +104,10 @@ describe('Bash Task', () => {
     td.verify(logger.info('foo'), { times: 0 });
     td.verify(logger.success('foo'), { times: 0 });
     td.verify(logger.warn('foo'), { times: 0 });
-    td.verify(logger.error('foo'), { times: 1 });
+    td.verify(logger.error('foo'), { times: 0 });
+    td.verify(logger.stdoutVerbose('foo'), { times: 0 });
+    td.verify(logger.stdout('foo'), { times: 0 });
+    td.verify(logger.stderr('foo'), { times: 1 });
 
     deferred.resolve();
 


### PR DESCRIPTION
This fixes https://github.com/isleofcode/corber/issues/604.

Turns out cordova-lib doesn't actually log to stdout/stderr by default, unlike cordova-cli, instead it emits events which I've hooked up.

Now the problem is it's hard to preserve the newlines, I've got it sort of working for cordova raw stdout, but it's a bit ugly. The same problem applies to e.g. the bash wrapper too, and I've probably broken the logger tests, so still needs a bit more work but interested in initial thoughts.