### PR TITLE
Document "reload-url" command line argument for "corber start" command

### DIFF
--- a/pages/cli.md
+++ b/pages/cli.md
@@ -129,14 +129,14 @@ more integrated experience for emulator usage.
 | Options    | default | desc |
 |---------  |---------| ---- |
 | platform  | ios | cordova platform |
-| reloadUrl | auto detected ip | network ip of your machine |
+| reload-url | auto detected ip | network ip of your machine |
 | cordova-output-path| corber/cordova/www | |
 | skip-framework-build (alias: sfb) | false | only performs cordova build |
 | skip-cordova-build (alias: scb) | false | only performs framework build |
 
 ### Examples
 + `corber serve`
-+ `corber serve --platform=android --reloadUrl=192.168.1.1`
++ `corber serve --platform=android --reload-url=192.168.1.1`
 + `corber serve --platform=browser --env "development"`
 
 ***

--- a/pages/cli.md
+++ b/pages/cli.md
@@ -78,6 +78,7 @@ To learn more, [read here](/pages/development-workflow)
 |---------  |---------| ---- |
 | platform  | ios | platform |
 | skip-cordova-build (alias: scb) | false | only performs framework build |
+| reload-url | auto detected ip | network ip of your machine |
 
 ### Examples
 + `corber start`


### PR DESCRIPTION
It wasn't clear to me that it was a command line argument until I checked the source at https://github.com/isleofcode/corber/blob/5726968ed7b97aac5c1f0a34611eb77a5520df2e/lib/commands/start.js#L33