### PR TITLE
Fix Windows events.js error and colours not outputting through console

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -249,6 +249,7 @@ module.exports = Command.extend({
       })
       .catch((e) => {
         logger.error(e);
+        logger.error(e.stack);
         throw e;
       });
   }

--- a/lib/targets/android/utils/apk-path.js
+++ b/lib/targets/android/utils/apk-path.js
@@ -2,15 +2,22 @@ const path            = require('path');
 const spawn           = require('../../../utils/spawn');
 const RSVP            = require('rsvp');
 const Promise         = RSVP.Promise;
+const fs              = require('fs');
+const util           = require('util');
 
-const findApk = function(values) {
-  let files = values.split('\n');
-  files = files.filter(function(file) {
-    if (file.match(/apk/)) { return file; }
-  });
+const readdir = util.promisify(fs.readdir);
 
-  //return the last modified apk
-  return files[files.length - 1];
+const readAndReturnDir = function(dir){
+  return readdir(dir).then(files => {
+    return {
+      files,
+      dir
+    };
+  })
+}
+
+const isApk = function(filename) {
+  return filename.match(/apk/);
 };
 
 module.exports = function(root, isDebug) {
@@ -25,18 +32,29 @@ module.exports = function(root, isDebug) {
   /* eslint-enable max-len */
 
   let lookups = [];
-  lookups.push(spawn('ls', ['-r', gradlePath]));
-  lookups.push(spawn('ls', ['-r', studioPath]));
+  lookups.push(readAndReturnDir(gradlePath));
+  lookups.push(readAndReturnDir(studioPath));
 
   return RSVP.allSettled(lookups).then(function(promises) {
-    if (promises[0].state === 'fulfilled' && promises[0].value.stdout) {
-      let apkName = findApk(promises[0].value.stdout);
-      return path.join(gradlePath, apkName);
-    } else if (promises[1].state === 'fulfilled' && promises[1].value.stdout) {
-      let apkName = findApk(promises[1].value.stdout);
-      return path.join(studioPath, apkName);
-    } else {
-      return Promise.reject('No apk found');
+    //Loop through each of the results in the promise list
+    for (let result of promises) {
+      //Only for working promises
+      if (result.state === 'fulfilled') {
+        let {
+          files,
+          dir
+        } = result.value;
+        //The promise returns a list of filenames, loop through them
+        for (let name of files) {
+          //Check if the file is an apk
+          if (isApk(name)) {
+            //Add the file to the path and return it
+            return path.join(dir, name);
+          }
+        }
+      }
     }
+    //Otherwise reject the promise because we have no apks
+    return Promise.reject('No apk found');
   });
 };

--- a/lib/tasks/bash.js
+++ b/lib/tasks/bash.js
@@ -14,7 +14,8 @@ module.exports = Task.extend({
   run() {
     let options = defaults(this.options, {
       // expands `this.command` as shell expression with args, pipes, etc.
-      shell: true
+      shell: true,
+      stdio: 'inherit'
     });
 
     return spawn(this.command, [], options, {

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -56,6 +56,11 @@ module.exports = function(command, args = [], processOpts = {}, opts = {}) {
     });
   });
 
+  spawned.on('error', (err) => {
+    deferred.reject(err);
+  });
+
+
   if (processPath) {
     deferred.promise.finally(() => {
       process.chdir(processPath);

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -27,21 +27,24 @@ module.exports = function(command, args = [], processOpts = {}, opts = {}) {
   let stdoutLines = [];
   let stderrLines = [];
 
-  spawned.stdout.on('data', (data) => {
-    stdoutLines.push(data);
+  // eslint-disable-next-line no-eq-null
+  if (processOpts.stdio == null) {
+    spawned.stdout.on('data', (data) => {
+      stdoutLines.push(data);
 
-    if (onStdout) {
-      onStdout(data.toString());
-    }
-  });
+      if (onStdout) {
+        onStdout(data.toString());
+      }
+    });
 
-  spawned.stderr.on('data', (data) => {
-    stderrLines.push(data);
+    spawned.stderr.on('data', (data) => {
+      stderrLines.push(data);
 
-    if (onStderr) {
-      onStderr(data.toString());
-    }
-  });
+      if (onStderr) {
+        onStderr(data.toString());
+      }
+    });
+  }
 
   spawned.on('exit', (code) => {
     if (code === EXIT_CODE_NOT_FOUND) {


### PR DESCRIPTION
Fixes #652 

Fix apk path on windows not reading directory with spawn ls command, used fs.readdir instead
Fix error not correctly capturing to console because error is not caught in promise
Fix stdio not inheriting when framework is spawned, this allows colours to flow through the console for errors

Firstly, the output from the spawn command was not getting logged to the console, because it needed the promise to listen to the on('error', function(){}) event in the childprocess spawn function.
Secondly, I adjusted the code to hopefully work cross platform, as running ls on all platforms is confusing and you may have different results, whereas the fs readdir command should be a cross platform directory file list.
Thirdly, while I was in the code I noticed the build for emberjs did not output the colours relevant to errors or successes, and found you need to inherit something when you spawn a child for bash, so I just added that option to the command as well.

Only tested on windows, but I thought I would upload the fix for anyone having the same issue as me.