### PR TITLE
fix(apk-path): use readdirSync for windows support

### DIFF
--- a/lib/targets/android/target.js
+++ b/lib/targets/android/target.js
@@ -34,7 +34,9 @@ module.exports = CoreObject.extend({
 
   run() {
     let device = this.device;
-    return getApkPath(cdvPath(this.project), this.isDebug).then((apkPath) => {
+    return getApkPath(cdvPath(this.project), {
+      debug: this.isDebug
+    }).then((apkPath) => {
       if (device.deviceType === 'emulator') {
         return bootEm(device)
           .then(() => installAppEm(apkPath, device))

--- a/lib/targets/android/utils/apk-path.js
+++ b/lib/targets/android/utils/apk-path.js
@@ -1,21 +1,11 @@
-const path            = require('path');
-const spawn           = require('../../../utils/spawn');
-const RSVP            = require('rsvp');
-const Promise         = RSVP.Promise;
+const path    = require('path');
+const RSVP    = require('rsvp');
+const fs      = require('fs');
+const logger  = require('../../../utils/logger');
+const Promise = RSVP.Promise;
 
-const findApk = function(values) {
-  let files = values.split('\n');
-  files = files.filter(function(file) {
-    if (file.match(/apk/)) { return file; }
-  });
-
-  //return the last modified apk
-  return files[files.length - 1];
-};
-
-module.exports = function(root, isDebug) {
-  let buildType;
-  isDebug ? buildType = 'debug' : buildType = 'release';
+module.exports = function(root, opts = {}) {
+  let buildType = opts.debug ? 'debug' : 'release';
 
   //directory differs if build was with gradle vs studio
   /* eslint-disable max-len */
@@ -24,19 +14,27 @@ module.exports = function(root, isDebug) {
   let studioPath = path.join(basePath, 'app', 'build', 'outputs', 'apk', buildType);
   /* eslint-enable max-len */
 
-  let lookups = [];
-  lookups.push(spawn('ls', ['-r', gradlePath]));
-  lookups.push(spawn('ls', ['-r', studioPath]));
-
-  return RSVP.allSettled(lookups).then(function(promises) {
-    if (promises[0].state === 'fulfilled' && promises[0].value.stdout) {
-      let apkName = findApk(promises[0].value.stdout);
-      return path.join(gradlePath, apkName);
-    } else if (promises[1].state === 'fulfilled' && promises[1].value.stdout) {
-      let apkName = findApk(promises[1].value.stdout);
-      return path.join(studioPath, apkName);
-    } else {
-      return Promise.reject('No apk found');
+  let apkPaths = [gradlePath, studioPath].reduce((arr, dir) => {
+    if (!fs.existsSync(dir)) {
+      return arr;
     }
-  });
+
+    fs.readdirSync(dir).forEach((name) => {
+      if (name.match(/\.apk$/i)) {
+        arr.push(path.join(dir, name))
+      }
+    });
+
+    return arr;
+  }, []);
+
+  if (apkPaths.length === 0) {
+    return Promise.reject('No apk found')
+  }
+
+  if (apkPaths.length > 1) {
+    logger.warn(`More than one apk found; using ${apkPaths[0]}`)
+  }
+
+  return Promise.resolve(apkPaths[0]);
 };

--- a/node-tests/unit/targets/android/utils/apk-path-test.js
+++ b/node-tests/unit/targets/android/utils/apk-path-test.js
@@ -1,77 +1,119 @@
-const td              = require('testdouble');
-const Promise         = require('rsvp').Promise;
-const expect          = require('../../../../helpers/expect');
-const path            = require('path');
+const td                = require('testdouble');
+const expect            = require('../../../../helpers/expect');
+const path              = require('path');
+
+const root              = 'root';
+const basePath          = path.join(root, 'platforms', 'android');
+const gradleDebugPath   = path.join(basePath, 'build', 'outputs', 'apk', 'debug');
+const gradleReleasePath = path.join(basePath, 'build', 'outputs', 'apk', 'release');
+const studioDebugPath   = path.join(basePath, 'app', 'build', 'outputs', 'apk', 'debug');
+const studioReleasePath = path.join(basePath, 'app', 'build', 'outputs', 'apk', 'release');
 
 describe('Android apk paths util', function() {
-  afterEach(function() {
+  let fs;
+  let logger;
+  let getApkPath;
+
+  beforeEach(() => {
+    fs = td.replace('fs');
+    logger = td.replace('../../../../../lib/utils/logger');
+
+    td.when(fs.existsSync(gradleReleasePath)).thenReturn(true);
+    td.when(fs.existsSync(gradleDebugPath)).thenReturn(true);
+    td.when(fs.existsSync(studioReleasePath)).thenReturn(true);
+    td.when(fs.existsSync(studioDebugPath)).thenReturn(true);
+
+    getApkPath = require('../../../../../lib/targets/android/utils/apk-path');
+  });
+
+  afterEach(() => {
     td.reset();
   });
 
-  it('checks gradle & studio dirs', function() {
-    let calls = [];
-    td.replace('../../../../../lib/utils/spawn', function() {
-      calls.push([...arguments]);
-      return Promise.resolve({ stdout: 'fake-debug.apk' });
-    });
-    let apkPath = require('../../../../../lib/targets/android/utils/apk-path');
+  it('resolves to gradle release path if available', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn(['app.apk']);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn([]);
 
-    return apkPath('fakePath', true).then(function() {
-      let localizedPaths = [
-        path.join(
-          'fakePath',
-          'platforms',
-          'android',
-          'build',
-          'outputs',
-          'apk',
-          'debug'
-        ),
-        path.join(
-          'fakePath',
-          'platforms',
-          'android',
-          'app',
-          'build',
-          'outputs',
-          'apk',
-          'debug'
-        )
-      ];
+    let apkPath = path.join(gradleReleasePath, 'app.apk');
+    return expect(getApkPath(root)).to.eventually.equal(apkPath);
+  });
 
-      expect(calls[0]).to.deep.equal(['ls', ['-r', localizedPaths[0]]]);
-      expect(calls[1]).to.deep.equal(['ls', ['-r', localizedPaths[1]]]);
+  it('resolves to studio release path when gradle not available', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn([]);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn(['app.apk']);
+
+    let apkPath = path.join(studioReleasePath, 'app.apk');
+    return expect(getApkPath(root)).to.eventually.equal(apkPath);
+  });
+
+  it('prefers gradle release path over studio', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn(['app.apk']);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn(['app.apk']);
+
+    let apkPath = path.join(gradleReleasePath, 'app.apk');
+    return expect(getApkPath(root)).to.eventually.equal(apkPath);
+  });
+
+  it('does not reject if gradle dir does not exist', () => {
+    td.when(fs.existsSync(gradleReleasePath)).thenReturn(false);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn(['app.apk']);
+
+    return expect(getApkPath(root)).to.eventually.be.fulfilled;
+  });
+
+  it('does not reject if studio dir does not exist', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn(['app.apk']);
+    td.when(fs.existsSync(studioReleasePath)).thenReturn(false);
+
+    return expect(getApkPath(root)).to.eventually.be.fulfilled;
+  });
+
+  it('issues a warning if more than one apk found', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn(['app.apk']);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn(['app.apk']);
+
+    return getApkPath(root).then(() => {
+      td.verify(logger.warn(td.matchers.contains('More than one apk found')));
     });
   });
 
-  it('returns a matched apk file', function() {
-    td.replace('../../../../../lib/utils/spawn', function() {
-      return Promise.resolve({ stdout: 'fake-debug.apk'});
-    });
-    let apkPath = require('../../../../../lib/targets/android/utils/apk-path');
+  it('rejects if no apk found', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn([]);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn([]);
 
-    return apkPath('fakePath', true).then(function(found) {
-      let localizedPath = path.join(
-        'fakePath',
-        'platforms',
-        'android',
-        'build',
-        'outputs',
-        'apk',
-        'debug',
-        'fake-debug.apk'
-      );
-
-      expect(found).to.equal(localizedPath);
-    });
+    return expect(getApkPath(root)).to.eventually.be.rejected;
   });
 
-  it('rejects if nothing was returned', function() {
-    td.replace('../../../../../lib/utils/spawn', function() {
-      return Promise.reject();
-    });
-    let apkPath = require('../../../../../lib/targets/android/utils/apk-path');
+  it('does not match files without .apk extension', () => {
+    td.when(fs.readdirSync(gradleReleasePath)).thenReturn(['app.txt']);
+    td.when(fs.readdirSync(studioReleasePath)).thenReturn(['app.zip']);
 
-    return expect(apkPath('fakePath', true)).to.eventually.be.rejected;
+    return expect(getApkPath(root)).to.eventually.be.rejected;
+  });
+
+  context('when debug specified', () => {
+    it('resolves to gradle debug path if avaible', () => {
+      td.when(fs.readdirSync(gradleDebugPath)).thenReturn(['app.apk']);
+      td.when(fs.readdirSync(studioDebugPath)).thenReturn([]);
+
+      let apkPath = path.join(gradleDebugPath, 'app.apk');
+      return expect(getApkPath(root, { debug: true })).to.eventually.equal(apkPath);
+    });
+
+    it('resolves to studio debug path when gradle not available', () => {
+      td.when(fs.readdirSync(gradleDebugPath)).thenReturn([]);
+      td.when(fs.readdirSync(studioDebugPath)).thenReturn(['app.apk']);
+
+      let apkPath = path.join(studioDebugPath, 'app.apk');
+      return expect(getApkPath(root, { debug: true })).to.eventually.equal(apkPath);
+    });
+
+    it('prefers gradle debug path over studio', () => {
+      td.when(fs.readdirSync(gradleDebugPath)).thenReturn(['app.apk']);
+      td.when(fs.readdirSync(studioDebugPath)).thenReturn(['app.apk']);
+
+      let apkPath = path.join(gradleDebugPath, 'app.apk');
+      return expect(getApkPath(root, { debug: true })).to.eventually.equal(apkPath);
+    });
   });
 });


### PR DESCRIPTION
Addresses #652.

- use `readdirSync` instead of `spawn` (no concurrency benefit to async `readdir` during build and `readdirSync` makes test stubbing much easier, especially for node < 8 where we don't have util.promisify)
- makes `debug` an optional param
- improves testing coverage