### PR TITLE
fix(serve): options are not passed to ember

### DIFF
--- a/lib/frameworks/ember/framework.js
+++ b/lib/frameworks/ember/framework.js
@@ -93,6 +93,34 @@ module.exports = Framework.extend({
   },
 
   serve(options) {
+    for (let option in options) {
+      switch (option) {
+        case 'port':
+        case 'host':
+        case 'environment':
+          this.serveCommand += ` --${option}=${options[option]}`;
+          break;
+        case 'ssl':
+          if (options[option] === true) {
+            this.serveCommand += ` --${option}=${options[option]}`;
+          }
+
+          break;
+        case 'sslKey':
+          if (options.ssl === true) {
+            this.serveCommand += ` --ssl-key=${options[option]}`;
+          }
+
+          break;
+        case 'sslCert':
+          if (options.ssl === true) {
+            this.serveCommand += ` --ssl-cert=${options[option]}`;
+          }
+
+          break;
+      }
+    }
+
     let serve = new Serve({
       command: this.serveCommand,
       platform: options.platform

--- a/node-tests/unit/frameworks/ember/framework-test.js
+++ b/node-tests/unit/frameworks/ember/framework-test.js
@@ -76,6 +76,24 @@ describe('Ember Framework', function() {
     td.verify(serveDouble());
   });
 
+  it('serve uses optional arguments', function() {
+    let framework = initFramework();
+
+    const options = {
+      environment: 'local',
+      host: 'http://some.other.host',
+      port:4201,
+      platform: 'ios',
+      ssl: true,
+      sslCert: 'cert-path',
+      sslKey: 'key'
+    }
+
+    const expectedCommand = 'ember serve --environment=local --host=http://some.other.host --port=4201 --ssl=true --ssl-cert=cert-path --ssl-key=key'
+    framework.serve(options);
+    expect(framework.serveCommand).to.equal(expectedCommand);
+  });
+
   it('validateBuild calls _buildValidators then runs validators', function() {
     let runValidatorDouble = td.replace('../../../../lib/utils/run-validators');
     let framework = initFramework();


### PR DESCRIPTION
Fixes command line options not being passed to ember when working in live reload.

Recognizes the following as valid arguments to pass to `ember serve`:

- host
- port
- environment
- ssl
- ssl-key
- ssl-cert

Includes test