### PR TITLE
Replace instruments using xctrace

### DIFF
--- a/lib/targets/ios/tasks/list-devices.js
+++ b/lib/targets/ios/tasks/list-devices.js
@@ -6,25 +6,26 @@ const deserializeDevices = function(stdout) {
   if (stdout === undefined) { return devices; }
 
   let list = stdout.split('\n');
-  //First line is always 'known devices'
+
+  //First line is always '== Devices =='
   list.shift();
 
-  list.forEach((item) => {
-    if (item.trim() === '') { return; }
+  for (let item of list) {
+    let line = item.trim();
+
+    if (line === '') { continue; }
+    if (line === '== Simulators ==') { break; }
+
     let split = item.split(/[(]|[[]/g);
 
-    if (split[split.length - 1].includes('Simulator')) {
-      return;
-    }
-
     let deviceName = split[0].trim();
-    //Cant exclude from instruments
+    //Cant exclude from device list
     if (deviceName.includes('MacBook')) {
-      return;
+      continue;
     }
 
     let apiVersion = split[1].replace(')', '').trim();
-    let uuid = split[split.length - 1].replace(']', '').trim();
+    let uuid = split[split.length - 1].replace(')', '').trim();
 
     let device = new Device({
       platform: 'ios',
@@ -35,15 +36,15 @@ const deserializeDevices = function(stdout) {
     });
 
     devices.push(device);
-  });
+  }
 
   return devices;
 };
 
 module.exports = function() {
   let list = [
-    '/usr/bin/instruments',
-    ['-s','devices']
+    '/usr/bin/xctrace',
+    ['list', 'devices']
   ];
 
   return spawn(...list).then((output) => {

--- a/node-tests/unit/targets/ios/tasks/list-devices-test.js
+++ b/node-tests/unit/targets/ios/tasks/list-devices-test.js
@@ -3,15 +3,17 @@ const expect          = require('../../../../helpers/expect');
 const Device          = require('../../../../../lib/objects/device');
 const Promise         = require('rsvp').Promise;
 
-const spawnArgs       = ['/usr/bin/instruments', ['-s', 'devices']];
+const spawnArgs       = ['/usr/bin/xctrace', ['list', 'devices']];
 
 //yes - isleofcode.com is my actual device name
 //(turn on the hotspot and be branding all conference long!)
-const deviceList = `Known Devices
-Alex’s MacBook Pro (2) [uuid]
-isleofcode.com (12.1.2) [uuid]
-Apple TV (12.1) [uuid] (Simulator)
-iPhone X (12.1) [uuid] (Simulator)`
+const deviceList = `== Devices ==
+MacBook Pro (Tomasz) (uuid)
+isleofcode.com (12.1.2) (uuid)
+
+== Simulators ==
+Apple TV Simulator (12.1) (uuid)
+iPhone X Simulator (12.1) (uuid)`
 
 describe('iOS List Emulator Task', () => {
   let listDevices;


### PR DESCRIPTION
## CHANGELOG

- Replaces the usage of `/usr/bin/instruments` by `/usr/bin/xctrace`.

Resolves: #697 

## DESCRIPTION

`instruments` has been deprecated in Xcode 12.x and removed from Xcode 13.x. When using macOS Monterey, Xcode requires version 13.x that does not include `instruments` and causes compatibility issues with corber runs for iOS platform. It causes e.g. failing `corber start --platform=ios` command.

Deprecation details:
```
The instruments command is now deprecated in favor of its replacement: xctrace. Use xctrace to record, import, and export data from Instruments .trace files. (36641078)
```
Source: https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes