### PR TITLE
Don't validate `cordova-plugin-whitelist`

### DIFF
--- a/lib/targets/cordova/target.js
+++ b/lib/targets/cordova/target.js
@@ -1,6 +1,5 @@
 const CoreObject              = require('core-object');
 const Build                   = require('./tasks/build');
-const ValidatePlugin          = require('./validators/plugin');
 const ValidateSigningIdentity = require('../ios/validators/signing-identity');
 const AllowNavigation         = require('./validators/allow-navigation');
 const runValidators           = require('../../utils/run-validators');
@@ -46,14 +45,6 @@ module.exports = CoreObject.extend({
 
   validateServe() {
     let validators = this._buildValidators(true);
-
-    validators.push(
-      new ValidatePlugin({
-        project: this.project,
-        platform: this.platform,
-        pluginName: 'cordova-plugin-whitelist'
-      }).run()
-    );
 
     return runValidators(validators);
   },

--- a/node-tests/fixtures/corber-mock/corber/cordova/config.xml
+++ b/node-tests/fixtures/corber-mock/corber/cordova/config.xml
@@ -8,7 +8,6 @@
     Apache Cordova Team
   </author>
     <content src="index.html"/>
-    <plugin name="cordova-plugin-whitelist" spec="1"/>
     <plugin name="cordova-test-plugin" spec="1"/>
     <access origin="*"/>
     <allow-navigation href="*"/>


### PR DESCRIPTION
`cordova-plugin-whitelist` has been deprecated and integrated into Cordova Android 10, and it is therefore no longer necessary to validate its existence.

https://github.com/apache/cordova-plugin-whitelist#deprecation-notice